### PR TITLE
Phase 5: Circle PIN wallet, indexer/connector fixes, branded + humanized errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,16 @@ VITE_CONTRACT_REVENUE_ROUTER=
 
 # Chain indexing window (optional tuning)
 VITE_INDEX_LOOKBACK_BLOCKS=500000
-VITE_INDEX_CHUNK_BLOCKS=10000
+# MUST stay <= 9000: Arc caps eth_getLogs at a 10,000-block range. 10000 silently
+# fails every windowed query (no agents/tasks render). Keep at 9000.
+VITE_INDEX_CHUNK_BLOCKS=9000
 
 # Circle Modular Wallets (passkey smart accounts, gasless on Arc via Gas Station).
 # From console.circle.com → Modular Wallets. Arc testnet chain path = arcTestnet.
 VITE_CIRCLE_CLIENT_KEY=
 VITE_CIRCLE_CLIENT_URL=
 VITE_CIRCLE_CHAIN_PATH=arcTestnet
+
+# Circle user-controlled wallet (PIN/email) — the "extra connect" option.
+# Only the App ID is public; the entity secret + API key live on the backend.
+VITE_CIRCLE_UC_APP_ID=

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Polaris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Stablecoin-native settlement · sub-second finality · ~$0.01 fees · no human i
 
 Built for the **Lepton Agents Hackathon** (Canteen × Circle), June 2026.
 
-[Live agent runtime](https://polaris-agent-runtime-production.up.railway.app/health) · [Arcscan (verified contracts)](https://testnet.arcscan.app/address/0x2b27E33cf288a6cFCD19234b16827CC234497fCA#code)
+**[▶ Live app — polarisswarm.vercel.app](https://polarisswarm.vercel.app)**
+
+[Agent runtime (Railway)](https://polaris-agent-runtime-production.up.railway.app/health) · [Arcscan (verified contracts)](https://testnet.arcscan.app/address/0x2b27E33cf288a6cFCD19234b16827CC234497fCA#code)
 
 </div>
 
@@ -99,10 +101,25 @@ All six contracts are **verified on Arcscan** (names + source visible):
 | RevenueRouter | `0xED6d1aF5556a4407B09776cd64d28098880c7EAa` |
 | USDC (Arc native) | `0x3600000000000000000000000000000000000000` |
 
+- **Live app:** https://polarisswarm.vercel.app (Vercel)
 - **Agent runtime:** https://polaris-agent-runtime-production.up.railway.app (Railway)
 - **Network:** chain ID `5042002` · RPC `https://rpc.testnet.arc.network` · explorer `https://testnet.arcscan.app` · gas token USDC (6-dec ERC-20 interface).
 
 ## Deploy
+
+> **Checklist for the live deployment**
+>
+> **Vercel (polarisswarm.vercel.app)** — set these, then redeploy:
+> - all six `VITE_CONTRACT_*` addresses + `VITE_USDC_ADDRESS` (the V2 table above)
+> - `VITE_API_URL=https://polaris-agent-runtime-production.up.railway.app`
+> - `VITE_INDEX_CHUNK_BLOCKS=9000`  ← **required**; `10000` silently shows zero agents/tasks
+> - `VITE_CIRCLE_CLIENT_KEY` + `VITE_CIRCLE_CLIENT_URL` (passkey wallet)
+> - `VITE_CIRCLE_UC_APP_ID` (PIN wallet)
+>
+> **Railway (agent runtime)** — set these for the PIN-wallet backend + swarm:
+> - `CIRCLE_UC_API_KEY`, `CIRCLE_UC_ENTITY_SECRET`, `CIRCLE_UC_APP_ID` (enables `/api/uc/*`)
+> - `VERIFIER_SIGNER_KEY` (must match the address given to VerifierBridge at deploy)
+> - `OPENROUTER_API_KEY`, and `CIRCLE_WALLETS=1` to run the Circle-wallet swarm
 
 **Frontend → Vercel / Netlify.** Connect the repo; `vercel.json` / `netlify.toml` are committed (build `npm run build`, output `dist`, SPA rewrites, `--legacy-peer-deps`). Set the env vars below in the dashboard.
 
@@ -135,7 +152,12 @@ VITE_CIRCLE_CLIENT_KEY=
 VITE_CIRCLE_CLIENT_URL=        # e.g. https://modular-sdk.circle.com/v1/rpc/w3s/<app-token>
 VITE_CIRCLE_CHAIN_PATH=arcTestnet
 
-# Indexing window (optional)
+# Circle user-controlled wallet (PIN/email) — the extra connect option.
+# Only the App ID is public; the entity secret + API key live on the Railway runtime.
+VITE_CIRCLE_UC_APP_ID=        # from console.circle.com → Programmable Wallets → User-Controlled
+
+# Indexing window. KEEP CHUNK <= 9000: Arc caps eth_getLogs at a 10,000-block range,
+# so 10000 silently fails every query and NOTHING renders (no agents, no tasks).
 VITE_INDEX_LOOKBACK_BLOCKS=500000
 VITE_INDEX_CHUNK_BLOCKS=9000
 ```
@@ -160,6 +182,15 @@ VITE_CONTRACT_VERIFIER_BRIDGE=0xa04D9F64A96112B983c7ADdF7a20C22b72edF875
 X402_NETWORK=eip155:5042002
 X402_CHAIN=arcTestnet
 X402_SELLER=0x...                # paywall payee (defaults to the verifier signer)
+
+# Circle user-controlled wallets (PIN/email) — enables the /api/uc/* routes that
+# back the frontend "PIN wallet" connect option. Entity secret + API key are
+# SERVER-ONLY (never exposed to the browser). From console.circle.com.
+CIRCLE_UC_API_KEY=
+CIRCLE_UC_ENTITY_SECRET=
+CIRCLE_UC_APP_ID=                # same value as VITE_CIRCLE_UC_APP_ID
+CIRCLE_UC_BLOCKCHAIN=ARC-TESTNET
+CIRCLE_UC_ACCOUNT_TYPE=SCA       # gasless smart account
 
 # swarm — raw keys OR Circle wallets (CIRCLE_WALLETS=1, requires circle login on host)
 SWARM_POLL_MS=12000

--- a/README.md
+++ b/README.md
@@ -232,3 +232,12 @@ Get testnet USDC from the [Circle faucet](https://faucet.circle.com) — USDC is
 - **Agency** — agents genuinely run themselves (`server/agent-circle.js`): discover, decide, price, work, submit, settle. Verified live end-to-end on Arc.
 - **Circle** — agent MPC wallets + human passkey wallets + USDC escrow/staking/slashing + x402/Gateway nanopayments.
 - **Chain-native** — no database; the product is reconstructable entirely from Arc state, with on-chain deliverable attestations.
+
+## License
+
+[MIT](./LICENSE) © 2026 Polaris.
+
+The branded login-code email used by the Circle user-controlled wallet lives at
+[`branding/polaris-otp-email.html`](./branding/polaris-otp-email.html) — paste it
+into Circle Console → User-Controlled Wallets → email template (it keeps the
+`{{code}}` and `{{expiry_long}}` merge variables).

--- a/branding/polaris-otp-email.html
+++ b/branding/polaris-otp-email.html
@@ -1,0 +1,89 @@
+<!--
+  Polaris - login code email (Circle user-controlled wallets).
+
+  Paste this into: Circle Console > Programmable Wallets > User-Controlled >
+  Email template. It preserves Circle's merge variables {{code}} and
+  {{expiry_long}} - do not rename them.
+
+  Built as table-based HTML with inline CSS so it renders consistently across
+  Gmail, Outlook, and Apple Mail. The Polaris mark is drawn with the four-point
+  star glyph (U+2726) because email clients do not render SVG; to use an image
+  instead, host a PNG and swap the <span> star for:
+    <img src="https://polarisswarm.vercel.app/polaris-mark.png" width="26" height="26" alt="Polaris" style="display:block;border:0;" />
+-->
+<div style="margin:0;padding:0;background:#F6F7F9;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F6F7F9;padding:32px 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#FFFFFF;border:1px solid #E2E6EC;border-radius:16px;overflow:hidden;font-family:'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#0B1020;padding:26px 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="vertical-align:middle;">
+                    <span style="display:inline-block;font-size:26px;line-height:26px;color:#5B9BFF;">&#10022;</span>
+                  </td>
+                  <td style="vertical-align:middle;padding-left:10px;">
+                    <span style="font-size:20px;font-weight:700;letter-spacing:1px;color:#FFFFFF;">POLARIS</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:36px 32px 8px;">
+              <h1 style="margin:0 0 8px;font-size:22px;font-weight:700;color:#101622;">Log in to Polaris</h1>
+              <p style="margin:0 0 24px;font-size:15px;line-height:22px;color:#56647A;">
+                Use the verification code below to finish signing in to your Polaris wallet.
+              </p>
+
+              <!-- Code -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td align="center" style="background:#F6F7F9;border:1px solid #E2E6EC;border-radius:12px;padding:22px;">
+                    <div style="font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:34px;font-weight:700;letter-spacing:10px;color:#2D7EF8;">{{code}}</div>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:20px 0 0;font-size:13px;line-height:20px;color:#8E9AAC;">
+                This code expires in {{expiry_long}}. Enter it in Polaris to complete verification.
+                If you did not request this, you can safely ignore this email. No action is needed.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Divider -->
+          <tr>
+            <td style="padding:24px 32px 0;">
+              <div style="border-top:1px solid #E2E6EC;line-height:1px;font-size:1px;">&nbsp;</div>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:20px 32px 32px;">
+              <p style="margin:0 0 4px;font-size:14px;font-weight:600;color:#101622;">The Polaris Team</p>
+              <p style="margin:0 0 16px;font-size:13px;line-height:20px;color:#56647A;">
+                The AI Agent Payment Rail. Settled in USDC on Arc.
+              </p>
+              <p style="margin:0;font-size:12px;line-height:18px;color:#8E9AAC;">
+                <a href="https://polarisswarm.vercel.app" style="color:#2D7EF8;text-decoration:none;">polarisswarm.vercel.app</a>
+                &nbsp;&middot;&nbsp;
+                <a href="https://polarisswarm.vercel.app/docs" style="color:#2D7EF8;text-decoration:none;">Docs</a>
+              </p>
+              <p style="margin:12px 0 0;font-size:11px;line-height:16px;color:#B6BECC;">
+                &copy; 2026 Polaris. All rights reserved.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/contracts/post-tasks.mjs
+++ b/contracts/post-tasks.mjs
@@ -1,0 +1,95 @@
+import { ethers } from "ethers";
+import fs from "fs";
+
+const env = Object.fromEntries(
+  fs.readFileSync(".env", "utf8")
+    .split("\n")
+    .filter((l) => l.includes("=") && !l.trim().startsWith("#"))
+    .map((l) => { const i = l.indexOf("="); return [l.slice(0, i).trim(), l.slice(i + 1).trim()]; }),
+);
+
+const RPC = env.ARC_RPC_URL || "https://rpc.testnet.arc.network";
+const pk = env.PRIVATE_KEY || env.DEPLOYER_PRIVATE_KEY;
+const USDC = "0x3600000000000000000000000000000000000000";
+const ESCROW = env.VITE_CONTRACT_USDC_ESCROW || "0x2256D1F95f59DA5C23F2D8B18e138e339171C76E";
+const TASKREG = env.VITE_CONTRACT_TASK_REGISTRY || "0x1cc2ac9d45c7B1d261C05df5bf16E778B93DAA35";
+
+const p = new ethers.JsonRpcProvider(RPC, 5042002);
+const w = new ethers.Wallet(pk, p);
+
+const usdc = new ethers.Contract(USDC, [
+  "function approve(address,uint256) returns (bool)",
+  "function allowance(address,address) view returns (uint256)",
+  "function balanceOf(address) view returns (uint256)",
+], w);
+
+const taskReg = new ethers.Contract(TASKREG, [
+  "function submitTask(bytes32,uint256,uint256,uint256,string,string,string,string) external",
+], w);
+
+const U = (n) => ethers.parseUnits(String(n), 6);
+const DAY = 24 * 3600;
+
+// 15 real tasks across the agent capability mix (research/analysis/writing/code/summarization/general).
+const TASKS = [
+  ["research", "Research: Stablecoin L1 landscape 2026", "Survey the major stablecoin-native L1s and payment chains (Arc, and peers). Compare consensus, gas-token model, finality, and target use cases.", "Covers at least 4 chains; names consensus + gas model for each; cites concrete finality numbers; ends with a comparison table.", 3],
+  ["analysis", "Analyze: USDC as a native gas token tradeoffs", "Explain the pros and cons of using USDC as the native gas token of an L1 versus a separate volatile gas asset.", "Lists >=4 pros and >=4 cons; addresses fee predictability, UX, and validator economics; gives a clear recommendation.", 3],
+  ["writing", "Write: Landing-page hero copy for an agent marketplace", "Write punchy hero copy (headline + subhead + 3 bullet value props) for an autonomous AI-agent task marketplace settled in USDC.", "One headline under 10 words; subhead under 25 words; exactly 3 benefit bullets; tone confident, not hypey.", 2],
+  ["code", "Code: USDC transfer helper in TypeScript (viem)", "Write a TypeScript function using viem that sends an ERC-20 USDC transfer and waits for the receipt, with input validation.", "Compiles conceptually; validates address + amount; uses 6-decimal parsing; returns the tx hash; includes a short usage example.", 4],
+  ["summarization", "Summarize: How onchain escrow protects task payments", "Summarize how an escrow contract that locks a requester's budget and releases on a passing verdict protects both sides of a task market.", "Under 200 words; covers lock, release, refund, and slash paths; plain language a non-engineer understands.", 2],
+  ["research", "Research: x402 and agent micropayments", "Research the x402 payment standard and how it enables pay-per-call micropayments between autonomous agents.", "Explains the 402 flow; gives a concrete agent-to-agent example; notes settlement asset + batching; cites how Circle fits.", 3],
+  ["analysis", "Analyze: Reputation-staking vs pure-stake agent markets", "Analyze the design tradeoffs of combining a USDC stake with an evolving reputation score for ranking agents, versus stake alone.", "Defines both models; covers sybil resistance, cold-start, and slashing incentives; states which fits a task market and why.", 3],
+  ["writing", "Write: A 5-tweet thread explaining Polaris", "Write a 5-tweet thread explaining an autonomous agent task economy where agents hire, verify, and pay each other in USDC onchain.", "Exactly 5 tweets; each under 280 chars; tweet 1 hooks; tweet 5 has a clear call to action; no emojis.", 2],
+  ["code", "Code: keccak256 task-id helper", "Write a small TypeScript helper that derives a deterministic bytes32 task id from a title and a nonce, and a random one as fallback.", "Uses keccak256 over encoded inputs; returns a 0x-prefixed 32-byte hex; includes the random fallback; has a test example.", 3],
+  ["summarization", "Summarize: Deadline slashing for accountability", "Summarize why letting anyone slash an assigned agent that misses its deadline keeps an open task market honest.", "Under 180 words; explains who can call it, what happens to the stake, and why permissionless slashing matters.", 2],
+  ["research", "Research: Trusted execution environments for oracle settlement", "Research how TEEs (AWS Nitro, Intel SGX) can host an offchain verifier so settlement verdicts are tamper-resistant.", "Explains attestation; describes binding code measurement to a signing key; notes the onchain verification step; lists 2 risks.", 4],
+  ["analysis", "Analyze: Pricing strategy for autonomous bidding agents", "Analyze how an autonomous agent should price its bids (as a markup/discount on the task budget) to win work while staying profitable.", "Gives a concrete pricing rule; accounts for reputation, competition, and gas; includes a worked numeric example.", 3],
+  ["writing", "Write: Plain-English explainer of gasless smart accounts", "Write a short explainer of how passkey-based smart-account wallets let users transact without holding a separate gas token.", "Under 250 words; explains paymaster sponsorship; no jargon left undefined; ends with one concrete user benefit.", 2],
+  ["general", "General: Onboarding checklist for a new agent operator", "Produce a step-by-step checklist for someone who wants to run their own autonomous agent on the marketplace.", "Ordered steps; covers wallet, stake, capabilities, going online, and monitoring; >=7 actionable items.", 2],
+  ["code", "Code: Poll-and-bid loop pseudocode", "Write clear pseudocode for an agent loop that polls open tasks, decides whether to bid, places a bid, and fulfils wins.", "Shows the poll interval, the want/skip decision, the bid + award calls, and the produce-then-verify step; readable structure.", 3],
+];
+
+async function main() {
+  const bal = await usdc.balanceOf(w.address);
+  const total = TASKS.reduce((s, t) => s + t[4], 0);
+  console.log(`Requester ${w.address}`);
+  console.log(`USDC balance: ${ethers.formatUnits(bal, 6)} | total budgets: ${total} USDC (gas also paid in USDC)`);
+
+  // Approve escrow once for the full amount + headroom.
+  const need = U(total);
+  const cur = await usdc.allowance(w.address, ESCROW);
+  if (cur < need) {
+    console.log("approving escrow for", total, "USDC...");
+    const tx = await usdc.approve(ESCROW, need);
+    await tx.wait();
+    console.log("approved", tx.hash);
+  }
+
+  let nonce = await p.getTransactionCount(w.address);
+  const deadline = Math.floor(Date.now() / 1000) + 3 * DAY;
+  const posted = [];
+  for (let i = 0; i < TASKS.length; i++) {
+    const [taskType, title, description, rubric, budget] = TASKS[i];
+    const taskId = ethers.hexlify(ethers.randomBytes(32));
+    try {
+      const tx = await taskReg.submitTask(
+        taskId, U(budget), deadline, 70, title, description, rubric, taskType,
+        { nonce: nonce++ },
+      );
+      await tx.wait();
+      posted.push({ taskId, title, budget });
+      console.log(`  [${i + 1}/15] ${title} (${budget} USDC) -> ${tx.hash}`);
+    } catch (e) {
+      nonce--; // tx didn't consume the nonce
+      console.log(`  [${i + 1}/15] FAILED ${title}: ${e.shortMessage || e.message}`);
+      if ((e.shortMessage || e.message || "").toLowerCase().includes("insufficient")) {
+        console.log("  Out of funds — stopping early.");
+        break;
+      }
+    }
+  }
+  console.log(`\nPosted ${posted.length}/15 tasks.`);
+  fs.writeFileSync("posted-tasks.json", JSON.stringify(posted, null, 2));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/posted-tasks.json
+++ b/contracts/posted-tasks.json
@@ -1,0 +1,77 @@
+[
+  {
+    "taskId": "0x95cd58226af66c118c7124caf7447fcc7a9fe9046dd532f38828d7e45e5d3e65",
+    "title": "Research: Stablecoin L1 landscape 2026",
+    "budget": 3
+  },
+  {
+    "taskId": "0x329e5daa93f81c59ed3bc65d885ad88cc941eb5cce23b6337e08c6e4ab3484ef",
+    "title": "Analyze: USDC as a native gas token tradeoffs",
+    "budget": 3
+  },
+  {
+    "taskId": "0xe2591e855f581ca597eda2c7c97790de28a1f2f988cf940898ca0cb243f5506f",
+    "title": "Write: Landing-page hero copy for an agent marketplace",
+    "budget": 2
+  },
+  {
+    "taskId": "0x16b853553e9ee05a0c8b138862e77275eaa0f2b15727b2931ee6cb69903f4b07",
+    "title": "Code: USDC transfer helper in TypeScript (viem)",
+    "budget": 4
+  },
+  {
+    "taskId": "0x1ee2332367cba1ff8ff863e0ab1021138141b7fa64fdb7360e4bcf93a8886f7e",
+    "title": "Summarize: How onchain escrow protects task payments",
+    "budget": 2
+  },
+  {
+    "taskId": "0xe1ab300b8aa2e3eacbc70598f6c03d2a238d6f4e279d5b3da9fae71a08e7e876",
+    "title": "Research: x402 and agent micropayments",
+    "budget": 3
+  },
+  {
+    "taskId": "0xa6defdbebaf411e76a3c93cf9c0c0db6a0b1f318bd38bcfc840f3e3628408ca5",
+    "title": "Analyze: Reputation-staking vs pure-stake agent markets",
+    "budget": 3
+  },
+  {
+    "taskId": "0xd2d40451af750102a73b34e215f79964d1fc1cf6ee0560450d3a07adb92f1575",
+    "title": "Write: A 5-tweet thread explaining Polaris",
+    "budget": 2
+  },
+  {
+    "taskId": "0x4e69230f13664e86a94ab702323dd7b5b1bc2b2848396142a39fd5e7c3df42f4",
+    "title": "Code: keccak256 task-id helper",
+    "budget": 3
+  },
+  {
+    "taskId": "0x26d68a701dd4e8599044e480ceb05a6eea3cc6ebf0e8e0b8e0fdf1c2f2159654",
+    "title": "Summarize: Deadline slashing for accountability",
+    "budget": 2
+  },
+  {
+    "taskId": "0x1b0978f0c6e174c23b7a64997cc8a90f107731c0f7da90ec7dbf0db107afe175",
+    "title": "Research: Trusted execution environments for oracle settlement",
+    "budget": 4
+  },
+  {
+    "taskId": "0x9d355a95e769530b1207b44c5e1aec841b6d0dbfad54817a677508ad837cfcea",
+    "title": "Analyze: Pricing strategy for autonomous bidding agents",
+    "budget": 3
+  },
+  {
+    "taskId": "0x4c92b63f7573540465fffbe45327eb8b2761bf8ce4dd71adab4a92130d76451c",
+    "title": "Write: Plain-English explainer of gasless smart accounts",
+    "budget": 2
+  },
+  {
+    "taskId": "0x1981f9af9537c5155f6b83bb4d271c9086cc85151f1b347af667e6d8327e9300",
+    "title": "General: Onboarding checklist for a new agent operator",
+    "budget": 2
+  },
+  {
+    "taskId": "0x0e4af18ada74720f88ecbfda79a10420d6d7aceb17bc4a5b12575baea5a9dd26",
+    "title": "Code: Poll-and-bid loop pseudocode",
+    "budget": 3
+  }
+]

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/polaris-mark.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="description" content="Polaris - The AI Agent Payment Rail. AI agents hire, verify, and pay each other in USDC on Arc Network." />
     <meta name="theme-color" content="#020408" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@circle-fin/modular-wallets-core": "^1.0.13",
+        "@circle-fin/w3s-pw-web-sdk": "^1.1.11",
         "@tanstack/react-query": "^5.101.0",
         "clsx": "^2.1.1",
         "ethers": "^6.16.0",
@@ -439,6 +440,35 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@circle-fin/w3s-pw-web-sdk": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@circle-fin/w3s-pw-web-sdk/-/w3s-pw-web-sdk-1.1.11.tgz",
+      "integrity": "sha512-EPiIE+Os+atMHUUIodPQz6CSunSAQsClvqxBpxXNPW1CsvdNE5rnyhWDkiik8z53zgiXLtksYo0sek241edO2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dotenv": "^16.3.1",
+        "firebase": "^10.12.1",
+        "jsonwebtoken": "^9.0.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@circle-fin/w3s-pw-web-sdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@coinbase/cdp-sdk": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.51.0.tgz",
@@ -821,6 +851,569 @@
         "node": ">=14"
       }
     },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.8.tgz",
+      "integrity": "sha512-CVnHcS4iRJPqtIDc411+UmFldk0ShSK3OB+D0bKD8Ck5Vro6dbK5+APZpkuWpbfdL359DIQUnAaMLE+zs/PVyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.14.tgz",
+      "integrity": "sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-types": "0.8.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.2.tgz",
+      "integrity": "sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.10.13.tgz",
+      "integrity": "sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.8.tgz",
+      "integrity": "sha512-O49RGF1xj7k6BuhxGpHmqOW5hqBIAEbt2q6POW0lIywx7emYtzPDeQI+ryQpC4zbKX646SoVZ711TN1DBLNSOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.15.tgz",
+      "integrity": "sha512-zFIvIFFNqDXpOT2huorz9cwf56VT3oJYRFjSFYdSbGYEJYEaXjLJbfC79lx/zjx4Fh+yuN8pry3TtvwaevrGbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-types": "0.5.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
+      "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.2.tgz",
+      "integrity": "sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.43",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.43.tgz",
+      "integrity": "sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.10.13",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
+      "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.7.9.tgz",
+      "integrity": "sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.14.tgz",
+      "integrity": "sha512-2eczCSqBl1KUPJacZlFpQayvpilg3dxXLy9cSMTKtQMTQSmondUtPI47P3ikH3bQAXhzKLOE+qVxJ3/IRtu9pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-types": "0.12.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
+      "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.2.tgz",
+      "integrity": "sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.1.0.tgz",
+      "integrity": "sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
+      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-types": "1.0.5",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
+      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.2",
+        "@firebase/util": "1.10.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.7.3.tgz",
+      "integrity": "sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "@firebase/webchannel-wrapper": "1.0.1",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.38",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.38.tgz",
+      "integrity": "sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-types": "3.0.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.2.tgz",
+      "integrity": "sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.8.tgz",
+      "integrity": "sha512-Lo2rTPDn96naFIlSZKVd1yvRRqqqwiJk7cf9TZhUerwnPKgBzXy+aHE22ry+6EjCaQusUoNai6mU6p+G8QZT1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/auth-interop-types": "0.2.3",
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.14.tgz",
+      "integrity": "sha512-dZ0PKOKQFnOlMfcim39XzaXonSuPPAVuzpqA4ONTIdyaJK/OnBaIEVs/+BH4faa1a2tLeR+Jy15PKqDRQoNIJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-types": "0.6.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.2.tgz",
+      "integrity": "sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.9.tgz",
+      "integrity": "sha512-hlT7AwCiKghOX3XizLxXOsTFiFCQnp/oj86zp1UxwDGmyzsyoxtX+UIZyVyH/oBF5+XtblFG9KZzZQ/h+dpy+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.9.tgz",
+      "integrity": "sha512-2lfdc6kPXR7WaL4FCQSQUhXcPbI7ol3wF+vkgtU25r77OxPf8F/VmswQ7sgIkBBWtymn5ZF20TIKtnOj9rjb6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-types": "0.5.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.2.tgz",
+      "integrity": "sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
+      "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.12.tgz",
+      "integrity": "sha512-6q0pbzYBJhZEtUoQx7hnPhZvAbuMNuBXKQXOx2YlWhSrlv9N1m0ZzlNpBbu/ItTzrwNKTibdYzUyaaxdWLg+4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/messaging-interop-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.12.tgz",
+      "integrity": "sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.2.tgz",
+      "integrity": "sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.9.tgz",
+      "integrity": "sha512-PnVaak5sqfz5ivhua+HserxTJHtCar/7zM0flCX6NkzBNzJzyzlH4Hs94h2Il0LQB99roBqoE5QT1JqWqcLJHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.9.tgz",
+      "integrity": "sha512-dNl95IUnpsu3fAfYBZDCVhXNkASE0uo4HYaEPd2/PKscfTvsgqFAOxfAXzBEDOnynDWiaGUnb5M1O00JQ+3FXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-types": "0.2.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.2.tgz",
+      "integrity": "sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.9.tgz",
+      "integrity": "sha512-EO1NLCWSPMHdDSRGwZ73kxEEcTopAxX1naqLJFNApp4hO8WfKfmEpmjxmP5TrrnypjIf2tUkYaKsfbEA7+AMmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/installations": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.9.tgz",
+      "integrity": "sha512-AxzGpWfWFYejH2twxfdOJt5Cfh/ATHONegTd/a0p5flEzsD5JsxXgfkFToop+mypEL3gNwawxrxlZddmDoNxyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-types": "0.3.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
+      "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.2.tgz",
+      "integrity": "sha512-fxuJnHshbhVwuJ4FuISLu+/76Aby2sh+44ztjF2ppoe0TELIDxPW6/r1KGlWYt//AD0IodDYYA8ZTN89q8YqUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0",
+        "undici": "6.19.7"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.12.tgz",
+      "integrity": "sha512-hA4VWKyGU5bWOll+uwzzhEMMYGu9PlKQc1w4DWxB3aIErWYzonrZjF0icqNQZbwKNIdh8SHjZlFeB2w6OSsjfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.6.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-types": "0.8.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.2.tgz",
+      "integrity": "sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/vertexai-preview": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/vertexai-preview/-/vertexai-preview-0.0.4.tgz",
+      "integrity": "sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.2",
+        "@firebase/component": "0.6.9",
+        "@firebase/logger": "0.4.2",
+        "@firebase/util": "1.10.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.1.tgz",
+      "integrity": "sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@gemini-wallet/core": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@gemini-wallet/core/-/core-0.3.2.tgz",
@@ -832,6 +1425,104 @@
       },
       "peerDependencies": {
         "viem": ">=2.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1670,6 +2361,63 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@reown/appkit": {
       "version": "1.7.8",
@@ -5653,6 +6401,12 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/bufferutil": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
@@ -6289,6 +7043,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6320,6 +7086,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
@@ -6495,7 +7270,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7068,6 +7842,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -7136,6 +7922,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.14.1.tgz",
+      "integrity": "sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.8",
+        "@firebase/analytics-compat": "0.2.14",
+        "@firebase/app": "0.10.13",
+        "@firebase/app-check": "0.8.8",
+        "@firebase/app-check-compat": "0.3.15",
+        "@firebase/app-compat": "0.2.43",
+        "@firebase/app-types": "0.9.2",
+        "@firebase/auth": "1.7.9",
+        "@firebase/auth-compat": "0.5.14",
+        "@firebase/data-connect": "0.1.0",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-compat": "1.0.8",
+        "@firebase/firestore": "4.7.3",
+        "@firebase/firestore-compat": "0.3.38",
+        "@firebase/functions": "0.11.8",
+        "@firebase/functions-compat": "0.3.14",
+        "@firebase/installations": "0.6.9",
+        "@firebase/installations-compat": "0.2.9",
+        "@firebase/messaging": "0.12.12",
+        "@firebase/messaging-compat": "0.2.12",
+        "@firebase/performance": "0.6.9",
+        "@firebase/performance-compat": "0.2.9",
+        "@firebase/remote-config": "0.4.9",
+        "@firebase/remote-config-compat": "0.2.9",
+        "@firebase/storage": "0.13.2",
+        "@firebase/storage-compat": "0.3.12",
+        "@firebase/util": "1.10.0",
+        "@firebase/vertexai-preview": "0.0.4"
       }
     },
     "node_modules/flat-cache": {
@@ -7466,6 +8288,12 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -7474,6 +8302,12 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
@@ -7896,6 +8730,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keccak": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
@@ -8286,6 +9175,60 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -9290,6 +10233,29 @@
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-compare": {
       "version": "2.6.0",
@@ -10404,6 +11370,15 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.7.tgz",
+      "integrity": "sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -11302,6 +12277,29 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@circle-fin/modular-wallets-core": "^1.0.13",
+    "@circle-fin/w3s-pw-web-sdk": "^1.1.11",
     "@tanstack/react-query": "^5.101.0",
     "clsx": "^2.1.1",
     "ethers": "^6.16.0",

--- a/server/.env.example
+++ b/server/.env.example
@@ -42,3 +42,12 @@ X402_ORACLE_URL=http://localhost:8787/api/oracle/price
 # OFF by default (0). Set e.g. 1 to delegate once an agent has 1 task in flight.
 DELEGATE_THRESHOLD=0
 DELEGATE_MARGIN=0.8
+
+# Circle user-controlled wallets (PIN/email) — human "extra connect" option.
+# Entity secret + API key are SERVER-ONLY (never exposed to the browser).
+# From console.circle.com → Programmable Wallets → User-Controlled.
+CIRCLE_UC_API_KEY=
+CIRCLE_UC_ENTITY_SECRET=
+CIRCLE_UC_APP_ID=
+CIRCLE_UC_BLOCKCHAIN=ARC-TESTNET
+CIRCLE_UC_ACCOUNT_TYPE=SCA

--- a/server/agent-circle.js
+++ b/server/agent-circle.js
@@ -227,6 +227,8 @@ async function main() {
       { name: "Atlas-Research", capabilities: ["research", "analysis", "summarization"], markup: 0.85 },
       { name: "Scribe-Writer", capabilities: ["writing", "translation"], markup: 0.9 },
       { name: "Forge-Coder", capabilities: ["code"], markup: 0.88 },
+      { name: "Nova-Analyst", capabilities: ["analysis", "research", "general"], markup: 0.82 },
+      { name: "Vega-Generalist", capabilities: ["general", "writing", "summarization"], markup: 0.8 },
     ];
     agents = wallets.slice(0, personas.length).map((address, i) => ({ ...personas[i], address, stake: 100 }));
     console.log(`Auto-mapped ${agents.length} Circle wallet(s) to personas.`);

--- a/server/agent.js
+++ b/server/agent.js
@@ -18,7 +18,7 @@ const X402_ORACLE = process.env.X402_PAY_FOR_ORACLE === "1" ? process.env.X402_O
  *   2. poll for OPEN tasks via TaskSubmitted events
  *   3. DECIDE whether to bid (capability match + reputation gate + price policy)
  *   4. place a bid, then close the auction (awardBid)
- *   5. if they win, DO the work via Claude, submit the deliverable, and trigger
+ *   5. if they win, DO the work, submit the deliverable, and trigger
  *      verification — which settles USDC on-chain
  *
  * Configure one or more agents via AGENTS_JSON (see .env.example). Each agent is

--- a/server/circle-user.js
+++ b/server/circle-user.js
@@ -1,0 +1,84 @@
+import { initiateUserControlledWalletsClient } from "@circle-fin/user-controlled-wallets";
+import { randomUUID } from "node:crypto";
+import "dotenv/config";
+
+/**
+ * Circle user-controlled wallets (PIN/email) for Polaris — the human-side
+ * "extra connect" option alongside the passkey Modular Wallet.
+ *
+ * The entity secret + API key live ONLY here on the backend. The browser runs
+ * the PIN ceremony with @circle-fin/w3s-pw-web-sdk using a short-lived userToken
+ * + encryptionKey that this module mints. Contract writes (submitTask, placeBid,
+ * ...) are initiated here as challenges and signed by the user with their PIN.
+ *
+ * Arc testnet is supported by the user-controlled wallets API (verified), so the
+ * wallet created is a real Arc account that can hold USDC and call the contracts.
+ */
+const API_KEY = process.env.CIRCLE_UC_API_KEY;
+const ENTITY_SECRET = process.env.CIRCLE_UC_ENTITY_SECRET;
+const BLOCKCHAIN = process.env.CIRCLE_UC_BLOCKCHAIN || "ARC-TESTNET";
+const ACCOUNT_TYPE = process.env.CIRCLE_UC_ACCOUNT_TYPE || "SCA"; // gasless smart account
+
+let client = null;
+export function ucEnabled() {
+  return Boolean(API_KEY && ENTITY_SECRET);
+}
+function uc() {
+  if (!ucEnabled()) throw new Error("Circle user-controlled wallets not configured");
+  if (!client) client = initiateUserControlledWalletsClient({ apiKey: API_KEY, entitySecret: ENTITY_SECRET });
+  return client;
+}
+
+/** Create a fresh user + session token. The browser uses these to run the ceremony. */
+export async function createSession() {
+  const c = uc();
+  const userId = `polaris-${randomUUID()}`;
+  await c.createUser({ userId });
+  const tok = await c.createUserToken({ userId });
+  return { userId, userToken: tok.data.userToken, encryptionKey: tok.data.encryptionKey };
+}
+
+/** Mint a fresh session token for an existing user (re-login). */
+export async function refreshSession(userId) {
+  const c = uc();
+  const tok = await c.createUserToken({ userId });
+  return { userId, userToken: tok.data.userToken, encryptionKey: tok.data.encryptionKey };
+}
+
+/** Challenge that sets the PIN and creates the Arc wallet in one ceremony. */
+export async function initChallenge(userId) {
+  const c = uc();
+  const res = await c.createUserPinWithWallets({
+    userId,
+    blockchains: [BLOCKCHAIN],
+    accountType: ACCOUNT_TYPE,
+  });
+  return { challengeId: res.data.challengeId };
+}
+
+/** The user's Arc wallet (id + address), once the ceremony has completed. */
+export async function getWallet(userId) {
+  const c = uc();
+  const res = await c.listWallets({ userId, blockchain: BLOCKCHAIN });
+  const w = res.data?.wallets?.[0];
+  if (!w) return null;
+  return { walletId: w.id, address: w.address, state: w.state };
+}
+
+/**
+ * Initiate a contract write from the user's wallet. Returns a challengeId the
+ * browser signs with the user's PIN. callData is an ABI function signature +
+ * positional parameters (Circle encodes them).
+ */
+export async function contractExecutionChallenge(userId, walletId, contractAddress, abiFunctionSignature, abiParameters) {
+  const c = uc();
+  const res = await c.createUserTransactionContractExecutionChallenge({
+    userId,
+    walletId,
+    contractAddress,
+    abiFunctionSignature,
+    abiParameters,
+    fee: { type: "level", config: { feeLevel: "MEDIUM" } },
+  });
+  return { challengeId: res.data.challengeId };
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@circle-fin/user-controlled-wallets": "^10.6.0",
         "@circle-fin/x402-batching": "^3.1.2",
         "@x402/core": "^2.15.0",
         "@x402/evm": "^2.15.0",
@@ -23,6 +24,14 @@
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "license": "MIT"
+    },
+    "node_modules/@circle-fin/user-controlled-wallets": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@circle-fin/user-controlled-wallets/-/user-controlled-wallets-10.6.0.tgz",
+      "integrity": "sha512-aBqAjrIueSQiFaqiL595AG7uJ/K9TrEPSVfeqeV94CSHlpYlnw8ViTjNb+6UbNVLWAUNsYsorcoMH01JQR1LGg==",
+      "dependencies": {
+        "axios": "^1.15.0"
+      }
     },
     "node_modules/@circle-fin/x402-batching": {
       "version": "3.1.2",
@@ -223,11 +232,64 @@
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.5",
@@ -291,6 +353,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -351,6 +425,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -438,6 +521,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -556,6 +654,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -644,6 +778,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -675,6 +824,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -924,6 +1109,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/qs": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "swarm:circle": "node agent-circle.js"
   },
   "dependencies": {
+    "@circle-fin/user-controlled-wallets": "^10.6.0",
     "@circle-fin/x402-batching": "^3.1.2",
     "@x402/core": "^2.15.0",
     "@x402/evm": "^2.15.0",

--- a/server/server.js
+++ b/server/server.js
@@ -7,12 +7,13 @@ import "dotenv/config";
 import { createGatewayMiddleware } from "@circle-fin/x402-batching/server";
 import { ADDR, ABI, provider, readTaskMeta, readAssignedAgent, requireAddresses } from "./chain.js";
 import { scoreAgentWork } from "./score.js";
+import { ucEnabled, createSession, refreshSession, initChallenge, getWallet, contractExecutionChallenge } from "./circle-user.js";
 
 /**
  * Polaris verifier backend.
  *   POST /api/deliverable      store an agent's deliverable (off-chain blob)
  *   GET  /api/deliverable/:id  fetch it
- *   POST /api/verify           score with Claude → sign verdict → settle on-chain
+ *   POST /api/verify           score with our algorithm → sign verdict → settle on-chain
  *
  * Holds the trusted verifier signer key; the frontend never sees it. The signed
  * verdict drives USDCEscrow release/slash via VerifierBridge.submitVerification.
@@ -72,7 +73,7 @@ app.post("/api/verify", async (req, res) => {
     const agent = (await readAssignedAgent(taskId)) || entry.agentWallet;
     if (!agent) return res.status(400).json({ error: "Task has no assigned agent" });
 
-    // 1. Score with Claude
+    // 1. Score with our algorithm
     const verdict = await scoreAgentWork({
       taskDescription: `${meta.title}\n\n${meta.description}`,
       qualityRubric: meta.rubric,
@@ -152,6 +153,65 @@ if (X402_SELLER) {
   }
 } else {
   console.log("x402 sub-service disabled (set X402_SELLER or VERIFIER_SIGNER_KEY to enable)");
+}
+
+// ── Circle user-controlled wallets (PIN/email) — human "extra connect" ──────
+if (ucEnabled()) {
+  app.get("/api/uc/enabled", (_req, res) => res.json({ enabled: true }));
+
+  app.post("/api/uc/session", async (_req, res) => {
+    try {
+      res.json(await createSession());
+    } catch (e) {
+      res.status(502).json({ error: e.message });
+    }
+  });
+
+  app.post("/api/uc/refresh", async (req, res) => {
+    const { userId } = req.body ?? {};
+    if (!userId) return res.status(400).json({ error: "userId required" });
+    try {
+      res.json(await refreshSession(userId));
+    } catch (e) {
+      res.status(502).json({ error: e.message });
+    }
+  });
+
+  app.post("/api/uc/init", async (req, res) => {
+    const { userId } = req.body ?? {};
+    if (!userId) return res.status(400).json({ error: "userId required" });
+    try {
+      res.json(await initChallenge(userId));
+    } catch (e) {
+      res.status(502).json({ error: e.message });
+    }
+  });
+
+  app.get("/api/uc/wallet", async (req, res) => {
+    const { userId } = req.query ?? {};
+    if (!userId) return res.status(400).json({ error: "userId required" });
+    try {
+      res.json((await getWallet(userId)) ?? {});
+    } catch (e) {
+      res.status(502).json({ error: e.message });
+    }
+  });
+
+  app.post("/api/uc/execute", async (req, res) => {
+    const { userId, walletId, contractAddress, abiFunctionSignature, abiParameters } = req.body ?? {};
+    if (!userId || !walletId || !contractAddress || !abiFunctionSignature) {
+      return res.status(400).json({ error: "userId, walletId, contractAddress, abiFunctionSignature required" });
+    }
+    try {
+      res.json(await contractExecutionChallenge(userId, walletId, contractAddress, abiFunctionSignature, abiParameters ?? []));
+    } catch (e) {
+      res.status(502).json({ error: e.message });
+    }
+  });
+
+  console.log("Circle user-controlled wallets: POST /api/uc/{session,init,execute} enabled");
+} else {
+  console.log("Circle user-controlled wallets disabled (set CIRCLE_UC_API_KEY + CIRCLE_UC_ENTITY_SECRET)");
 }
 
 app.listen(PORT, () => {

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
-import { Fingerprint, LogOut, ChevronDown, Copy, Check, KeyRound, X } from "lucide-react";
+import { Fingerprint, LogOut, ChevronDown, Copy, Check, KeyRound, X, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { useWallet } from "../context/WalletProvider";
 import { shortAddr, fmtUSDC } from "../lib/utils";
+import { humanizeError } from "../lib/errors";
 import { USDCAmount } from "./ui/primitives";
 
 /**
@@ -12,7 +13,7 @@ import { USDCAmount } from "./ui/primitives";
  * not brand name.
  */
 export default function WalletButton() {
-  const { address, isConnected, circle, balance, lastUsername, disconnect } = useWallet();
+  const { address, isConnected, circle, uc, balance, lastUsername, disconnect } = useWallet();
   const [menuOpen, setMenuOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -34,7 +35,7 @@ export default function WalletButton() {
         >
           {balance != null && <span className="hidden text-grey-l sm:inline">{fmtUSDC(balance)} USDC</span>}
           <span className="grid h-5 w-5 place-items-center rounded-full bg-blue-violet text-[9px] text-white">
-            {circle ? (circle.username[0] || "C").toUpperCase() : "•"}
+            {circle ? (circle.username[0] || "C").toUpperCase() : uc ? "P" : "•"}
           </span>
           <span>{shortAddr(address)}</span>
           <ChevronDown size={13} className="text-grey" />
@@ -44,7 +45,9 @@ export default function WalletButton() {
           <>
             <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
             <div className="absolute right-0 z-50 mt-2 w-64 rounded-xl border border-border bg-card p-3 shadow-panel">
-              <div className="eyebrow mb-1 !text-[9px]">{circle ? `Passkey wallet · ${circle.username}` : "Injected wallet"}</div>
+              <div className="eyebrow mb-1 !text-[9px]">
+                {circle ? `Passkey wallet · ${circle.username}` : uc ? "PIN wallet · Circle" : "Injected wallet"}
+              </div>
               <div className="mb-3 flex items-center justify-between rounded-lg border border-border bg-deep px-3 py-2">
                 <span className="mono text-xs text-grey-l">{shortAddr(address, 8, 6)}</span>
                 <button onClick={copy} className="text-grey hover:text-blue-l" title="Copy address">
@@ -55,7 +58,7 @@ export default function WalletButton() {
                 <div className="eyebrow mb-1 !text-[9px]">USDC Balance</div>
                 <USDCAmount amount={balance ?? 0} size="md" className="text-white" />
               </div>
-              {circle && (
+              {(circle || uc) && (
                 <button
                   onClick={() => {
                     disconnect();
@@ -86,7 +89,7 @@ export default function WalletButton() {
 
 /* ── Centered connect modal ─────────────────────────────────────────────────*/
 function ConnectModal({ onClose, lastUsername }: { onClose: () => void; lastUsername: string | null }) {
-  const { circleEnabled, connecting, connect } = useWallet();
+  const { circleEnabled, ucEnabled, hasUcUser, connecting, connect, connectUserWallet } = useWallet();
   const [view, setView] = useState<"options" | "create" | "login">(lastUsername ? "login" : "options");
   const [username, setUsername] = useState(lastUsername ?? "");
 
@@ -104,7 +107,17 @@ function ConnectModal({ onClose, lastUsername }: { onClose: () => void; lastUser
       onClose();
       toast.success(mode === "register" ? "Wallet created" : "Welcome back");
     } catch (e) {
-      toast.error((e as Error).message || "Passkey failed");
+      toast.error(humanizeError(e, "Could not connect your passkey wallet. Please try again."));
+    }
+  };
+
+  const goPin = async () => {
+    try {
+      await connectUserWallet(hasUcUser ? "login" : "register");
+      onClose();
+      toast.success(hasUcUser ? "Welcome back" : "Wallet created");
+    } catch (e) {
+      toast.error(humanizeError(e, "Could not set up your PIN wallet. Please try again."));
     }
   };
 
@@ -144,6 +157,18 @@ function ConnectModal({ onClose, lastUsername }: { onClose: () => void; lastUser
               desc="Return to a wallet you already created with your passkey."
               onClick={() => setView("login")}
             />
+            {ucEnabled && (
+              <OptionRow
+                icon={<Lock size={18} />}
+                title={hasUcUser ? "Unlock your PIN wallet" : "Create a PIN wallet"}
+                desc={
+                  hasUcUser
+                    ? "Return to the wallet you secured with a PIN on this device."
+                    : "Secured by a PIN, recoverable across devices. Gasless on Arc."
+                }
+                onClick={goPin}
+              />
+            )}
           </div>
         ) : (
           <div className="flex flex-col gap-4">

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -92,11 +92,11 @@ function Sidebar({
         ))}
       </nav>
 
-      {!collapsed && (
-        <div className="mono px-5 pt-3 text-[10px] leading-relaxed text-grey">
-          Arc · USDC · sub-second finality
-        </div>
-      )}
+      {/* bottom: theme toggle + tagline */}
+      <div className={cn("mt-auto flex items-center gap-2 border-t border-border px-3 pt-4", collapsed ? "flex-col" : "justify-between")}>
+        <ThemeToggle />
+        {!collapsed && <span className="mono text-[10px] leading-tight text-grey">Arc · USDC<br />sub-second finality</span>}
+      </div>
     </aside>
   );
 }
@@ -130,7 +130,6 @@ function Topbar({
         <span className="mono hidden rounded-full border border-blue/30 bg-blue/10 px-2.5 py-1 text-[10px] uppercase tracking-widest text-blue-l md:inline">
           Arc Testnet
         </span>
-        <ThemeToggle />
         <WalletButton />
       </div>
     </header>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 import Logo from "../brand/Logo";
-import { ARC_EXPLORER } from "../../lib/chain";
 
 const REPO = "https://github.com/bigneb1/polaris";
 
@@ -29,19 +28,13 @@ export default function Footer() {
           ["Docs", "/docs"],
           ["Create a task", "/create-task"],
           ["My dashboard", "/profile"],
-        ]} />
-
-        <FooterCol title="Network" links={[
-          ["Arc Testnet", ARC_EXPLORER, true],
           ["GitHub", REPO, true],
-          ["Circle", "https://www.circle.com", true],
         ]} />
       </div>
 
       <div className="border-t border-border">
-        <div className="mx-auto flex max-w-[1320px] flex-col items-center justify-between gap-2 px-6 py-5 text-xs text-grey sm:flex-row">
-          <span className="mono">© {} Polaris. Built on Arc, settled in USDC.</span>
-          <span className="mono">Chain 5042002 · Arc Testnet</span>
+        <div className="mx-auto flex max-w-[1320px] items-center justify-center px-6 py-5 text-xs text-grey">
+          <span className="mono">© Polaris. Built on Arc, settled in USDC.</span>
         </div>
       </div>
     </footer>

--- a/src/components/ui/primitives.tsx
+++ b/src/components/ui/primitives.tsx
@@ -140,7 +140,7 @@ export function ProgressBar({ value, max = 100 }: { value: number; max?: number 
   );
 }
 
-/* ── Reputation bar (0–1000 scale) ────────────────────────────────────────── */
+/* ── Reputation bar (0-1000 scale) ────────────────────────────────────────── */
 export function ReputationBar({ rep }: { rep: number }) {
   const pct = Math.max(0, Math.min(100, (rep / 1000) * 100));
   const color = rep >= 700 ? "bg-green" : rep >= 400 ? "bg-blue" : "bg-amber";

--- a/src/context/WalletProvider.tsx
+++ b/src/context/WalletProvider.tsx
@@ -7,6 +7,13 @@ import {
   circleUsdcBalance,
   type CircleSession,
 } from "../lib/circleWallet";
+import {
+  ucWalletEnabled,
+  registerUserWallet,
+  loginUserWallet,
+  ucUsdcBalance,
+  type UcSession,
+} from "../lib/circleUserWallet";
 
 /**
  * Wallet layer for Polaris. Circle Modular Wallets (passkey smart accounts) are
@@ -14,18 +21,27 @@ import {
  * in later with the same passkey.
  */
 const LAST_USER_KEY = "polaris-circle-username";
+const LAST_UC_KEY = "polaris-uc-userid";
 
 type Ctx = {
   address?: `0x${string}`;
   isConnected: boolean;
   circle: CircleSession | null;
+  /** Circle user-controlled (PIN/email) session, when that wallet is connected. */
+  uc: UcSession | null;
+  /** Whichever Circle session is active (passkey or PIN), for routing writes. */
+  signer: CircleSession | UcSession | null;
   circleEnabled: boolean;
+  ucEnabled: boolean;
   connecting: boolean;
   /** USDC balance of the connected wallet (human units), refreshed periodically. */
   balance: number | null;
   /** Last username this browser registered/logged in with (for quick re-login). */
   lastUsername: string | null;
+  /** Whether this browser has a remembered user-controlled wallet to re-login. */
+  hasUcUser: boolean;
   connect: (username: string, mode: "register" | "login") => Promise<void>;
+  connectUserWallet: (mode: "register" | "login") => Promise<void>;
   disconnect: () => void;
   refreshBalance: () => void;
 };
@@ -35,11 +51,19 @@ const WalletCtx = createContext<Ctx | null>(null);
 export function WalletProvider({ children }: { children: ReactNode }) {
   const { address: injected } = useAccount();
   const [circle, setCircle] = useState<CircleSession | null>(null);
+  const [uc, setUc] = useState<UcSession | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [balance, setBalance] = useState<number | null>(null);
   const [lastUsername, setLastUsername] = useState<string | null>(() => {
     try {
       return localStorage.getItem(LAST_USER_KEY);
+    } catch {
+      return null;
+    }
+  });
+  const [lastUcUser, setLastUcUser] = useState<string | null>(() => {
+    try {
+      return localStorage.getItem(LAST_UC_KEY);
     } catch {
       return null;
     }
@@ -50,6 +74,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     try {
       const session = mode === "register" ? await registerCircleWallet(username) : await loginCircleWallet(username);
       setCircle(session);
+      setUc(null);
       try {
         localStorage.setItem(LAST_USER_KEY, username);
       } catch {
@@ -61,30 +86,60 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const connectUserWallet = useCallback(
+    async (mode: "register" | "login") => {
+      setConnecting(true);
+      try {
+        const session =
+          mode === "login" && lastUcUser ? await loginUserWallet(lastUcUser) : await registerUserWallet();
+        setUc(session);
+        setCircle(null);
+        try {
+          localStorage.setItem(LAST_UC_KEY, session.userId);
+        } catch {
+          /* ignore */
+        }
+        setLastUcUser(session.userId);
+      } finally {
+        setConnecting(false);
+      }
+    },
+    [lastUcUser],
+  );
+
   const refreshBalance = useCallback(() => {
     if (circle) circleUsdcBalance(circle).then(setBalance).catch(() => setBalance(null));
-  }, [circle]);
+    else if (uc) ucUsdcBalance(uc).then(setBalance).catch(() => setBalance(null));
+  }, [circle, uc]);
 
   useEffect(() => {
-    if (!circle) {
+    if (!circle && !uc) {
       setBalance(null);
       return;
     }
     refreshBalance();
     const id = setInterval(refreshBalance, 15000);
     return () => clearInterval(id);
-  }, [circle, refreshBalance]);
+  }, [circle, uc, refreshBalance]);
 
   const value: Ctx = {
-    address: (circle?.address ?? injected) as `0x${string}` | undefined,
-    isConnected: Boolean(circle || injected),
+    address: (circle?.address ?? uc?.address ?? injected) as `0x${string}` | undefined,
+    isConnected: Boolean(circle || uc || injected),
     circle,
+    uc,
+    signer: circle ?? uc,
     circleEnabled: circleEnabled(),
+    ucEnabled: ucWalletEnabled(),
     connecting,
     balance,
     lastUsername,
+    hasUcUser: Boolean(lastUcUser),
     connect,
-    disconnect: () => setCircle(null),
+    connectUserWallet,
+    disconnect: () => {
+      setCircle(null);
+      setUc(null);
+    },
     refreshBalance,
   };
 

--- a/src/hooks/useTx.ts
+++ b/src/hooks/useTx.ts
@@ -2,13 +2,12 @@ import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import type { Hash } from "viem";
 import { explorerTx } from "../lib/chain";
-
-type TxError = { code?: number; shortMessage?: string; message?: string };
+import { humanizeError, isUserRejection } from "../lib/errors";
 
 /**
  * Standard transaction runner: drives the pending → confirmed → explorer-link
  * toast flow used by every write in the app, and exposes a `loading` flag.
- * Handles user-rejection (code 4001) quietly.
+ * Wallet/RPC errors are humanized; user rejection is handled quietly.
  */
 export function useTx() {
   const [loading, setLoading] = useState(false);
@@ -22,18 +21,21 @@ export function useTx() {
       const toastId = toast.loading(opts.pending);
       try {
         const hash = await fn();
+        // PIN-wallet writes settle async and return no single hash ("0x").
+        const hasHash = typeof hash === "string" && hash.length > 2;
         toast.success(opts.success, {
           id: toastId,
-          action: { label: "View tx", onClick: () => window.open(explorerTx(hash), "_blank") },
+          ...(hasHash
+            ? { action: { label: "View tx", onClick: () => window.open(explorerTx(hash), "_blank") } }
+            : {}),
         });
         opts.onDone?.(hash);
         return hash;
       } catch (err) {
-        const e = err as TxError;
-        if (e.code === 4001 || /reject|denied/i.test(e.shortMessage ?? e.message ?? "")) {
-          toast.error("Cancelled by user", { id: toastId });
+        if (isUserRejection(err)) {
+          toast.error("Cancelled.", { id: toastId });
         } else {
-          toast.error(e.shortMessage || "Transaction failed", { id: toastId });
+          toast.error(humanizeError(err, "Transaction failed. Please try again."), { id: toastId });
           // eslint-disable-next-line no-console
           console.error(err);
         }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 /**
  * Client for the Polaris verifier backend (backend/server.js).
  *
- * The backend holds the trusted verifier signer key, runs Claude scoring, and
+ * The backend holds the trusted verifier signer key, runs the scoring, and
  * relays the signed verdict to VerifierBridge.sol. The frontend never sees the
  * signer key. If VITE_API_URL is unset we assume the backend is served on the
  * same origin under /api.
@@ -35,7 +35,7 @@ export async function getDeliverable(taskId: string): Promise<{ deliverable: str
 }
 
 /**
- * Trigger verification: backend scores with Claude, signs, and calls
+ * Trigger verification: backend scores the work, signs, and calls
  * VerifierBridge.submitVerification - which releases USDC or slashes the stake.
  */
 export async function verifyTask(taskId: string): Promise<VerifyResult> {

--- a/src/lib/circleUserWallet.ts
+++ b/src/lib/circleUserWallet.ts
@@ -1,0 +1,198 @@
+/**
+ * Circle user-controlled wallets (PIN / email): the human "extra connect"
+ * option alongside the passkey Modular Wallet.
+ *
+ * The entity secret + API key NEVER touch the browser. This module talks to the
+ * Polaris backend (/api/uc/*) for the session token + challenge IDs, and runs
+ * the PIN ceremony locally with @circle-fin/w3s-pw-web-sdk. Contract writes are
+ * initiated on the backend as challenges and signed here with the user's PIN.
+ */
+import { W3SSdk } from "@circle-fin/w3s-pw-web-sdk";
+import { createPublicClient, http, encodeFunctionData, erc20Abi, formatUnits, type Abi } from "viem";
+import { arcTestnet, USDC_ADDRESS, USDC_DECIMALS, ARC_RPC_URL } from "./chain";
+
+const ENV = (import.meta as { env?: Record<string, string> }).env ?? {};
+const API_URL = ENV.VITE_API_URL || "";
+const APP_ID = ENV.VITE_CIRCLE_UC_APP_ID || "";
+
+export function ucWalletEnabled(): boolean {
+  return Boolean(API_URL && APP_ID);
+}
+
+export type UcSession = {
+  kind: "uc";
+  userId: string;
+  userToken: string;
+  encryptionKey: string;
+  walletId: string;
+  address: `0x${string}`;
+};
+
+const publicClient = createPublicClient({ chain: arcTestnet, transport: http(ARC_RPC_URL) });
+
+async function api<T>(path: string, body?: unknown): Promise<T> {
+  const r = await fetch(`${API_URL}${path}`, {
+    method: body ? "POST" : "GET",
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `request to ${path} failed`);
+  return r.json() as Promise<T>;
+}
+
+/** The Polaris brand mark, served from the app origin (falls back gracefully). */
+function brandLogo(): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return `${origin}/polaris-mark.svg`;
+}
+
+/** Apply Polaris branding (logo, palette, typography, copy) to the PIN ceremony. */
+function brandSdk(sdk: W3SSdk): void {
+  const logo = brandLogo();
+
+  // Palette mirrors the Polaris light theme: white surfaces, blue/violet accents.
+  sdk.setThemeColor({
+    backdrop: "#0B1020",
+    backdropOpacity: 0.6,
+    bg: "#FFFFFF",
+    divider: "#E2E6EC",
+    textMain: "#101622",
+    textMain2: "#101622",
+    textAuxiliary: "#56647A",
+    textAuxiliary2: "#8E9AAC",
+    textSummary: "#101622",
+    textSummaryHighlight: "#256EE6",
+    textPlaceholder: "#8E9AAC",
+    textInteractive: "#256EE6",
+    textDetailToggle: "#256EE6",
+    success: "#0D9464",
+    error: "#DC3232",
+    pinDotBase: "#FFFFFF",
+    pinDotBaseBorder: "#D0D6E0",
+    pinDotActivated: "#256EE6",
+    enteredPinText: "#101622",
+    inputText: "#101622",
+    inputBorderFocused: "#256EE6",
+    inputBorderFocusedError: "#DC3232",
+    inputBg: "#F6F7F9",
+  });
+
+  sdk.setResources({
+    securityIntroMain: logo,
+    emailIcon: logo,
+    dAppIcon: logo,
+    fontFamily: {
+      name: "Outfit",
+      url: "https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap",
+    },
+  });
+
+  sdk.setLocalizations({
+    common: { continue: "Continue", confirm: "Confirm", sign: "Approve", retry: "Try again" },
+    initPincode: {
+      headline: "Secure your Polaris wallet",
+      subhead: "Set a 6-digit PIN. It protects your wallet and signs your transactions on Arc.",
+    },
+    confirmInitPincode: {
+      headline: "Confirm your PIN",
+      subhead: "Re-enter your PIN to finish creating your Polaris wallet.",
+    },
+    enterPincode: {
+      headline: "Enter your Polaris PIN",
+      subhead: "Confirm this action with the PIN you set for your wallet.",
+    },
+  });
+}
+
+function makeSdk(userToken: string, encryptionKey: string): W3SSdk {
+  const sdk = new W3SSdk();
+  sdk.setAppSettings({ appId: APP_ID });
+  sdk.setAuthentication({ userToken, encryptionKey });
+  brandSdk(sdk);
+  return sdk;
+}
+
+/** Run a Circle challenge (PIN ceremony / tx signing). Resolves on success. */
+function runChallenge(sdk: W3SSdk, challengeId: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sdk.execute(challengeId, (error) => {
+      if (error) reject(new Error(error.message || "challenge failed"));
+      else resolve();
+    });
+  });
+}
+
+async function fetchWallet(userId: string): Promise<{ walletId: string; address: `0x${string}` }> {
+  // The wallet may take a moment to materialize after the ceremony.
+  for (let i = 0; i < 8; i++) {
+    const w = await api<{ walletId?: string; address?: string }>(`/api/uc/wallet?userId=${encodeURIComponent(userId)}`);
+    if (w.walletId && w.address) return { walletId: w.walletId, address: w.address as `0x${string}` };
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  throw new Error("wallet not ready");
+}
+
+/** First-time connect: create user, set a PIN, create the Arc wallet. */
+export async function registerUserWallet(): Promise<UcSession> {
+  if (!ucWalletEnabled()) throw new Error("Circle user wallet not configured");
+  const sess = await api<{ userId: string; userToken: string; encryptionKey: string }>("/api/uc/session", {});
+  const { challengeId } = await api<{ challengeId: string }>("/api/uc/init", { userId: sess.userId });
+  const sdk = makeSdk(sess.userToken, sess.encryptionKey);
+  await runChallenge(sdk, challengeId);
+  const wallet = await fetchWallet(sess.userId);
+  return { kind: "uc", ...sess, ...wallet };
+}
+
+/** Returning user (this browser remembered the userId): mint a fresh token. */
+export async function loginUserWallet(userId: string): Promise<UcSession> {
+  if (!ucWalletEnabled()) throw new Error("Circle user wallet not configured");
+  const sess = await api<{ userId: string; userToken: string; encryptionKey: string }>("/api/uc/refresh", { userId });
+  const wallet = await fetchWallet(userId);
+  return { kind: "uc", ...sess, ...wallet };
+}
+
+/** USDC balance (human units) of the user wallet. */
+export async function ucUsdcBalance(session: UcSession): Promise<number> {
+  const raw = (await publicClient.readContract({
+    address: USDC_ADDRESS,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [session.address],
+  })) as bigint;
+  return Number(formatUnits(raw, USDC_DECIMALS));
+}
+
+type Call = { address: `0x${string}`; abi: Abi; functionName: string; args: readonly unknown[] };
+
+/**
+ * Execute a single contract write from the user wallet: the backend builds a
+ * contract-execution challenge, the user signs it here with their PIN. Circle
+ * sponsors gas (SCA), so no native balance is required.
+ *
+ * Circle's challenge takes an ABI function signature + string params, so we
+ * derive the human signature from the call and stringify the args.
+ */
+export async function ucWrite(session: UcSession, call: Call): Promise<void> {
+  const abiFunctionSignature = humanSignature(call);
+  const abiParameters = call.args.map((a) => (typeof a === "bigint" ? a.toString() : a));
+  // Validate encodability up-front (throws clearly if the call is malformed).
+  encodeFunctionData({ abi: call.abi, functionName: call.functionName, args: call.args });
+  const { challengeId } = await api<{ challengeId: string }>("/api/uc/execute", {
+    userId: session.userId,
+    walletId: session.walletId,
+    contractAddress: call.address,
+    abiFunctionSignature,
+    abiParameters,
+  });
+  const sdk = makeSdk(session.userToken, session.encryptionKey);
+  await runChallenge(sdk, challengeId);
+}
+
+/** Build a Solidity human-readable function signature, e.g. placeBid(bytes32,uint256,uint256). */
+function humanSignature(call: Call): string {
+  const frag = (call.abi as Array<{ type?: string; name?: string; inputs?: Array<{ type: string }> }>).find(
+    (f) => f.type === "function" && f.name === call.functionName,
+  );
+  if (!frag?.inputs) throw new Error(`ABI missing function ${call.functionName}`);
+  return `${call.functionName}(${frag.inputs.map((i) => i.type).join(",")})`;
+}

--- a/src/lib/circleWallet.ts
+++ b/src/lib/circleWallet.ts
@@ -14,7 +14,7 @@ import {
   encodeTransfer,
   WebAuthnMode,
 } from "@circle-fin/modular-wallets-core";
-import { createPublicClient, erc20Abi, formatUnits } from "viem";
+import { createPublicClient, encodeFunctionData, erc20Abi, formatUnits, type Abi } from "viem";
 import { toWebAuthnAccount, createBundlerClient } from "viem/account-abstraction";
 import { arcTestnet, USDC_ADDRESS, USDC_DECIMALS } from "./chain";
 
@@ -72,6 +72,33 @@ export async function circleUsdcBalance(session: CircleSession): Promise<number>
     args: [session.address],
   })) as bigint;
   return Number(formatUnits(raw, USDC_DECIMALS));
+}
+
+type Call = { address: `0x${string}`; abi: Abi; functionName: string; args: readonly unknown[] };
+
+/** Send one or more contract writes from the Circle smart account, gaslessly. */
+export async function circleWrite(session: CircleSession, calls: Call[]): Promise<`0x${string}`> {
+  const encoded = calls.map((c) => ({
+    to: c.address,
+    data: encodeFunctionData({ abi: c.abi, functionName: c.functionName, args: c.args }),
+  }));
+  const hash = await session.bundler.sendUserOperation({
+    account: session.account,
+    calls: encoded,
+    paymaster: true,
+  });
+  const { receipt } = await session.bundler.waitForUserOperationReceipt({ hash });
+  return receipt.transactionHash as `0x${string}`;
+}
+
+/** Read a contract view via the Circle public client. */
+export async function circleRead(session: CircleSession, call: Omit<Call, "args"> & { args?: readonly unknown[] }) {
+  return session.publicClient.readContract({
+    address: call.address,
+    abi: call.abi,
+    functionName: call.functionName,
+    args: call.args as never,
+  });
 }
 
 /** Send a gasless USDC transfer (paymaster-sponsored). */

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,121 @@
+/**
+ * Turn raw wallet / RPC / contract errors into short, human messages.
+ *
+ * viem, wagmi and the Circle bundler throw verbose multi-line errors with stack
+ * traces, ABI dumps, "Version: viem@x.y.z" footers and request payloads. Surfacing
+ * those in a toast looks broken. This module extracts the one useful line (a
+ * contract revert reason, a user rejection, or a network failure) and maps it to
+ * plain language. Everything unrecognized falls back to a clean generic message.
+ */
+
+type AnyErr = {
+  code?: number | string;
+  name?: string;
+  reason?: string;
+  shortMessage?: string;
+  details?: string;
+  message?: string;
+  cause?: unknown;
+};
+
+/** Friendly text for the Solidity require() strings used across the contracts. */
+const REVERT_MAP: Record<string, string> = {
+  "Below min stake (100 USDC)": "You need to stake at least 100 USDC to register an agent.",
+  "Already registered": "This wallet already has a registered agent.",
+  "agentId taken": "That agent name is already taken. Try another.",
+  "USDC transferFrom failed": "USDC transfer failed. Check your balance and allowance.",
+  "Agent reputation below 70": "This agent's reputation is below the 70 floor required to bid.",
+  "Agent offline": "That agent is offline and cannot be hired right now.",
+  "Deadline in past": "The deadline must be in the future.",
+  "Zero budget": "Set a task budget greater than zero.",
+  "Task exists": "A task with this id already exists.",
+  "Not authorized": "This wallet is not authorized for that action.",
+  "Auction closed": "Bidding on this task has already closed.",
+  "Has active tasks": "Finish or settle in-flight tasks before going offline.",
+  "Insufficient allowance": "Approve USDC spending first, then try again.",
+};
+
+/** Walk the cause chain collecting candidate message strings. */
+function collect(err: unknown, out: string[] = [], depth = 0): string[] {
+  if (!err || depth > 6) return out;
+  const e = err as AnyErr;
+  for (const v of [e.reason, e.shortMessage, e.details, e.message]) {
+    if (typeof v === "string" && v.trim()) out.push(v.trim());
+  }
+  if (e.cause) collect(e.cause, out, depth + 1);
+  return out;
+}
+
+/** Extract a Solidity revert reason from any of the collected strings. */
+function revertReason(strings: string[]): string | null {
+  for (const s of strings) {
+    const m =
+      s.match(/reverted with the following reason:\s*\n?\s*(.+)/i) ||
+      s.match(/execution reverted:?\s*"?([^"\n]+)"?/i) ||
+      s.match(/reason:\s*"?([^"\n]+)"?/i);
+    if (m?.[1]) return m[1].trim();
+  }
+  return null;
+}
+
+function looksLikeUserRejection(strings: string[], code?: number | string): boolean {
+  if (code === 4001 || code === "ACTION_REJECTED") return true;
+  return strings.some((s) => /user (rejected|denied)|rejected the request|denied (the )?(transaction|signature)|cancell?ed/i.test(s));
+}
+
+function looksLikeNetwork(strings: string[]): boolean {
+  return strings.some((s) =>
+    /network|timeout|timed out|fetch failed|failed to fetch|ECONNRESET|503|502|gateway|rpc|connection/i.test(s),
+  );
+}
+
+/** First clean sentence of a string: drop viem footers, payloads, stack noise. */
+function firstClean(s: string): string {
+  const line = s
+    .split("\n")[0]
+    .replace(/\b(viem|wagmi)@?[\w.@/-]*/gi, "")
+    .replace(/Version:.*/i, "")
+    .replace(/https?:\/\/\S+/g, "")
+    .replace(/0x[0-9a-fA-F]{12,}/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+  return line;
+}
+
+/**
+ * Map any thrown error to a short, user-facing message.
+ * @param fallback default text when nothing useful can be extracted.
+ */
+export function humanizeError(err: unknown, fallback = "Something went wrong. Please try again."): string {
+  const e = err as AnyErr;
+  const strings = collect(err);
+
+  if (looksLikeUserRejection(strings, e.code)) return "Cancelled.";
+
+  const reason = revertReason(strings);
+  if (reason) return REVERT_MAP[reason] ?? `Transaction reverted: ${reason}`;
+
+  if (looksLikeNetwork(strings)) return "Network issue reaching Arc. Please try again in a moment.";
+
+  // Backend (Circle / verifier) errors already arrive as clean single-line messages.
+  for (const s of strings) {
+    const clean = firstClean(s);
+    // Skip noisy library boilerplate; surface a genuinely human sentence.
+    if (
+      clean &&
+      clean.length <= 140 &&
+      !/^the contract function/i.test(clean) &&
+      !/abi|encodefunctiondata|useroperation|estimateGas|^request|^contract call|^raw|^data:/i.test(clean)
+    ) {
+      return clean;
+    }
+  }
+
+  return fallback;
+}
+
+/** True if the error is just the user dismissing a wallet prompt. */
+export function isUserRejection(err: unknown): boolean {
+  const e = err as AnyErr;
+  return looksLikeUserRejection(collect(err), e.code);
+}

--- a/src/lib/tx.ts
+++ b/src/lib/tx.ts
@@ -9,6 +9,11 @@ import {
   AGENT_REGISTRY_ABI,
   BID_ENGINE_ABI,
 } from "./contracts";
+import { circleWrite, type CircleSession } from "./circleWallet";
+import { ucWrite, type UcSession } from "./circleUserWallet";
+
+/** Either Circle wallet kind, or null/undefined for the injected-wallet path. */
+export type Signer = CircleSession | UcSession | null | undefined;
 
 /** Random bytes32 id for a new task. */
 export function newTaskId(): `0x${string}` {
@@ -23,32 +28,41 @@ export function agentIdFrom(name: string, wallet: string): `0x${string}` {
 
 const usdc = (amount: number | string) => parseUnits(String(amount), USDC_DECIMALS);
 
+/* A single contract write description, used for both the wagmi and Circle paths. */
+type Write = { address: Address; abi: readonly unknown[]; functionName: string; args: readonly unknown[] };
+
 /**
- * Ensure `spender` has at least `amount` USDC allowance from `owner`; approves
- * the exact amount if not. Returns the approval tx hash when one was sent.
+ * Execute a sequence of writes. With a passkey Circle session they are batched
+ * into one gasless user operation; with a user-controlled (PIN) session each is
+ * signed in turn with the PIN; otherwise each runs through the injected wallet.
  */
-export async function ensureAllowance(
-  owner: Address,
-  spender: Address,
-  amount: number,
-): Promise<Hash | null> {
-  const need = usdc(amount);
-  const current = (await readContract(wagmiConfig, {
-    address: CONTRACTS.usdc,
-    abi: ERC20_ABI,
-    functionName: "allowance",
-    args: [owner, spender],
-  })) as bigint;
-  if (current >= need) return null;
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.usdc,
-    abi: ERC20_ABI,
-    functionName: "approve",
-    args: [spender, need],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+async function run(writes: Write[], signer?: Signer): Promise<Hash> {
+  if (signer && "kind" in signer && signer.kind === "uc") {
+    for (const w of writes) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await ucWrite(signer, w as any);
+    }
+    return "0x" as Hash; // PIN-signed challenges settle async; no single hash returned
+  }
+  if (signer) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return circleWrite(signer as CircleSession, writes as any);
+  }
+  let last: Hash = "0x" as Hash;
+  for (const w of writes) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    last = await writeContract(wagmiConfig, w as any);
+    await waitForTransactionReceipt(wagmiConfig, { hash: last });
+  }
+  return last;
 }
+
+const approve = (spender: Address, amount: number): Write => ({
+  address: CONTRACTS.usdc,
+  abi: ERC20_ABI,
+  functionName: "approve",
+  args: [spender, usdc(amount)],
+});
 
 export type SubmitTaskInput = {
   owner: Address;
@@ -62,119 +76,83 @@ export type SubmitTaskInput = {
   taskType: string;
 };
 
-/** Approve escrow, then submit the task (locks USDC). Returns the submit hash. */
-export async function submitTask(i: SubmitTaskInput): Promise<Hash> {
-  await ensureAllowance(i.owner, CONTRACTS.usdcEscrow, i.budgetUsdc);
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.taskRegistry,
-    abi: TASK_REGISTRY_ABI,
-    functionName: "submitTask",
-    args: [
-      i.taskId,
-      usdc(i.budgetUsdc),
-      BigInt(Math.floor(i.deadlineMs / 1000)),
-      BigInt(i.minReputation),
-      i.title,
-      i.description,
-      i.rubric,
-      i.taskType,
+/** Approve escrow + submit the task (locks USDC). */
+export async function submitTask(i: SubmitTaskInput, circle?: Signer): Promise<Hash> {
+  return run(
+    [
+      approve(CONTRACTS.usdcEscrow, i.budgetUsdc),
+      {
+        address: CONTRACTS.taskRegistry,
+        abi: TASK_REGISTRY_ABI,
+        functionName: "submitTask",
+        args: [
+          i.taskId,
+          usdc(i.budgetUsdc),
+          BigInt(Math.floor(i.deadlineMs / 1000)),
+          BigInt(i.minReputation),
+          i.title,
+          i.description,
+          i.rubric,
+          i.taskType,
+        ],
+      },
     ],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+    circle,
+  );
 }
 
-export async function registerAgent(input: {
-  owner: Address;
-  name: string;
-  capabilities: string[];
-  stakeUsdc: number;
-}): Promise<Hash> {
-  await ensureAllowance(input.owner, CONTRACTS.agentRegistry, input.stakeUsdc);
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.agentRegistry,
-    abi: AGENT_REGISTRY_ABI,
-    functionName: "register",
-    args: [
-      agentIdFrom(input.name, input.owner),
-      usdc(input.stakeUsdc),
-      input.name,
-      input.capabilities.join(","),
+export async function registerAgent(
+  input: { owner: Address; name: string; capabilities: string[]; stakeUsdc: number },
+  circle?: Signer,
+): Promise<Hash> {
+  return run(
+    [
+      approve(CONTRACTS.agentRegistry, input.stakeUsdc),
+      {
+        address: CONTRACTS.agentRegistry,
+        abi: AGENT_REGISTRY_ABI,
+        functionName: "register",
+        args: [agentIdFrom(input.name, input.owner), usdc(input.stakeUsdc), input.name, input.capabilities.join(",")],
+      },
     ],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+    circle,
+  );
 }
 
-export async function setAgentOnline(online: boolean, restakeUsdc = 0, owner?: Address): Promise<Hash> {
+export async function setAgentOnline(
+  online: boolean,
+  restakeUsdc = 0,
+  circle?: Signer,
+): Promise<Hash> {
   if (online) {
-    if (restakeUsdc > 0 && owner) await ensureAllowance(owner, CONTRACTS.agentRegistry, restakeUsdc);
-    const hash = await writeContract(wagmiConfig, {
-      address: CONTRACTS.agentRegistry,
-      abi: AGENT_REGISTRY_ABI,
-      functionName: "restake",
-      args: [usdc(restakeUsdc)],
-    });
-    await waitForTransactionReceipt(wagmiConfig, { hash });
-    return hash;
+    const writes: Write[] = [];
+    if (restakeUsdc > 0) writes.push(approve(CONTRACTS.agentRegistry, restakeUsdc));
+    writes.push({ address: CONTRACTS.agentRegistry, abi: AGENT_REGISTRY_ABI, functionName: "restake", args: [usdc(restakeUsdc)] });
+    return run(writes, circle);
   }
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.agentRegistry,
-    abi: AGENT_REGISTRY_ABI,
-    functionName: "deactivate",
-    args: [],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+  return run([{ address: CONTRACTS.agentRegistry, abi: AGENT_REGISTRY_ABI, functionName: "deactivate", args: [] }], circle);
 }
 
 /** Reclaim the full stake - only valid when the agent is offline and idle. */
-export async function withdrawStake(): Promise<Hash> {
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.agentRegistry,
-    abi: AGENT_REGISTRY_ABI,
-    functionName: "withdrawStake",
-    args: [],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+export async function withdrawStake(circle?: Signer): Promise<Hash> {
+  return run([{ address: CONTRACTS.agentRegistry, abi: AGENT_REGISTRY_ABI, functionName: "withdrawStake", args: [] }], circle);
 }
 
 export async function placeBid(
   taskId: `0x${string}`,
   bidUsdc: number,
   etaSeconds: number,
+  circle?: Signer,
 ): Promise<Hash> {
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.bidEngine,
-    abi: BID_ENGINE_ABI,
-    functionName: "placeBid",
-    args: [taskId, usdc(bidUsdc), BigInt(etaSeconds)],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+  return run([{ address: CONTRACTS.bidEngine, abi: BID_ENGINE_ABI, functionName: "placeBid", args: [taskId, usdc(bidUsdc), BigInt(etaSeconds)] }], circle);
 }
 
-export async function awardBid(taskId: `0x${string}`): Promise<Hash> {
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.bidEngine,
-    abi: BID_ENGINE_ABI,
-    functionName: "awardBid",
-    args: [taskId],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+export async function awardBid(taskId: `0x${string}`, circle?: Signer): Promise<Hash> {
+  return run([{ address: CONTRACTS.bidEngine, abi: BID_ENGINE_ABI, functionName: "awardBid", args: [taskId] }], circle);
 }
 
-export async function cancelTask(taskId: `0x${string}`): Promise<Hash> {
-  const hash = await writeContract(wagmiConfig, {
-    address: CONTRACTS.taskRegistry,
-    abi: TASK_REGISTRY_ABI,
-    functionName: "cancelTask",
-    args: [taskId],
-  });
-  await waitForTransactionReceipt(wagmiConfig, { hash });
-  return hash;
+export async function cancelTask(taskId: `0x${string}`, circle?: Signer): Promise<Hash> {
+  return run([{ address: CONTRACTS.taskRegistry, abi: TASK_REGISTRY_ABI, functionName: "cancelTask", args: [taskId] }], circle);
 }
 
 /** Read onchain USDC balance (human units) for an address. */

--- a/src/routes/Agents.tsx
+++ b/src/routes/Agents.tsx
@@ -59,7 +59,7 @@ export default function Agents() {
 }
 
 function RegisterForm() {
-  const { address } = useWallet();
+  const { address, signer } = useWallet();
   const { run, loading } = useTx();
   const [name, setName] = useState("");
   const [caps, setCaps] = useState<string[]>([]);
@@ -74,7 +74,7 @@ function RegisterForm() {
   const onSubmit = async () => {
     if (!address || !valid) return;
     await run(
-      () => registerAgent({ owner: address, name: name.trim(), capabilities: caps, stakeUsdc: stakeN }),
+      () => registerAgent({ owner: address, name: name.trim(), capabilities: caps, stakeUsdc: stakeN }, signer),
       { pending: "Approving stake & registering agent…", success: "Agent registered onchain" },
     );
     setName("");
@@ -141,13 +141,13 @@ function RegisterForm() {
 }
 
 function MyAgents({ isLoading }: { isLoading: boolean }) {
-  const { address } = useWallet();
+  const { address, signer } = useWallet();
   const { agents } = useAgents();
   const { run, loading } = useTx();
   const mine = agents.filter((a) => a.wallet.toLowerCase() === address?.toLowerCase());
 
   const toggleOnline = (online: boolean) =>
-    run(() => setAgentOnline(!online, 0, address ?? undefined), {
+    run(() => setAgentOnline(!online, 0, signer), {
       pending: online ? "Taking agent offline…" : "Bringing agent online…",
       success: online ? "Agent is now OFFLINE" : "Agent is now ONLINE",
     });

--- a/src/routes/CreateTask.tsx
+++ b/src/routes/CreateTask.tsx
@@ -28,7 +28,7 @@ export default function CreateTask() {
 }
 
 function Form() {
-  const { address } = useWallet();
+  const { address, signer } = useWallet();
   const navigate = useNavigate();
   const { run, loading } = useTx();
 
@@ -60,7 +60,7 @@ function Form() {
           description: description.trim(),
           rubric: rubric.trim(),
           taskType,
-        }),
+        }, signer),
       { pending: "Approving USDC & locking escrow…", success: "Task posted onchain" },
     );
     if (hash) navigate("/tasks");
@@ -106,7 +106,7 @@ function Form() {
             />
           </Field>
 
-          <Field label="Quality rubric" hint="Claude scores the deliverable against this, 0–100. Pass ≥ 70.">
+          <Field label="Quality rubric" hint="our algorithm scores the deliverable against this, 0-100. Pass ≥ 70.">
             <textarea
               className="input-field min-h-[90px] resize-y"
               placeholder="Accurate (40), well-cited (30), concise & clear (20), formatted (10)…"
@@ -171,7 +171,7 @@ function Form() {
             {[
               ["Lock", "Your USDC budget moves into USDCEscrow.sol the moment you post."],
               ["Bid", "Online agents that meet min-reputation bid; the engine ranks them."],
-              ["Verify", "The winner submits work; Claude scores it against your rubric."],
+              ["Verify", "The winner submits work; our algorithm scores it against your rubric."],
               ["Settle", "Score ≥ 70 releases USDC to the agent. Below, their stake is slashed."],
             ].map(([t, d], i) => (
               <li key={t} className="flex gap-3">

--- a/src/routes/Docs.tsx
+++ b/src/routes/Docs.tsx
@@ -126,7 +126,7 @@ export default function Docs() {
                 ["Post", "A requester (or another agent) posts a task with a budget, rubric and deadline. USDC locks in escrow."],
                 ["Bid", "Online agents that meet the reputation floor bid. Bids are ranked onchain by price (40%), reputation (40%) and speed (20%)."],
                 ["Work", "The winning agent produces the deliverable using its model and submits it."],
-                ["Verify", "An LLM scores the deliverable 0–100 against the rubric. The verdict, bound to a hash of the exact deliverable, is signed."],
+                ["Verify", "An LLM scores the deliverable 0-100 against the rubric. The verdict, bound to a hash of the exact deliverable, is signed."],
                 ["Settle", "Score 70 or higher releases USDC and raises reputation. Below 70 refunds the requester and slashes the stake. A missed deadline can be slashed by anyone."],
               ]} />
             </Section>
@@ -172,8 +172,38 @@ export default function Docs() {
               </p>
               <p className="rounded-xl border border-border bg-deep p-4 text-sm">
                 <b>Honest trust note:</b> verification today is a trusted-signer oracle, not a hardware or TEE
-                attestation. A signer-key compromise would compromise settlement. Decentralizing this (a
-                verifier committee, a ZK proof of scoring, or a real TEE) is the natural next step.
+                attestation. The verifier holds a key; a key compromise would compromise settlement. We state
+                this plainly rather than overclaim decentralization.
+              </p>
+
+              <h3 className="mt-6 text-base font-semibold">Roadmap: TEE settlement</h3>
+              <p>
+                The path to trust-minimized settlement is to move the scoring + signing step inside a Trusted
+                Execution Environment so no human can forge a verdict. The concrete migration:
+              </p>
+              <ol className="ml-5 list-decimal space-y-2 text-sm">
+                <li>
+                  Run the verifier inside an <b>AWS Nitro Enclave</b> (or Azure Confidential VM). The scoring
+                  model call and the signer key live only in enclave memory, sealed from the host operator.
+                </li>
+                <li>
+                  The enclave produces an <b>attestation document</b> (signed by the cloud provider root of
+                  trust) binding its code measurement (PCR hashes) to the public key it signs verdicts with.
+                </li>
+                <li>
+                  VerifierBridge is upgraded to accept verdicts only from a signer key whose enclave
+                  attestation has been registered, so the contract enforces <i>which code</i> produced the
+                  verdict, not merely <i>which key</i>.
+                </li>
+                <li>
+                  Anyone can independently verify the attestation document offchain and confirm the running
+                  code matches the open-source verifier, removing the trusted human entirely.
+                </li>
+              </ol>
+              <p className="text-sm text-grey-l">
+                Until that hardware is provisioned, Polaris ships the signed-oracle and labels it honestly. The
+                contract interface (signed digest over taskId, pass, score, deliverableHash) is already
+                forward-compatible with the enclave signer.
               </p>
             </Section>
 

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -6,7 +6,6 @@ import { useMarketStats } from "../lib/onchain";
 import { USDCAmount } from "../components/ui/primitives";
 import { fmtCompact } from "../lib/utils";
 import AgentAvatar from "../components/AgentAvatar";
-import ThemeToggle from "../components/ThemeToggle";
 import Footer from "../components/layout/Footer";
 
 const MODULES = [
@@ -34,11 +33,11 @@ const STEPS = [
   { icon: PlusSquare, t: "Post", d: "Task + rubric + USDC budget locks in escrow." },
   { icon: Bot, t: "Bid", d: "Agents bid; ranked by price, reputation & speed." },
   { icon: Cpu, t: "Work", d: "The winning agent executes and submits a deliverable." },
-  { icon: ShieldCheck, t: "Verify", d: "AI scores 0–100 against the rubric, signed." },
+  { icon: ShieldCheck, t: "Verify", d: "AI scores 0-100 against the rubric, signed." },
   { icon: Zap, t: "Settle", d: "Score ≥ 70 releases USDC; below slashes the stake." },
 ];
 
-const MARQUEE = ["ARC NETWORK", "USDC NATIVE", "SUB-SECOND FINALITY", "$0.01 FEES", "CLAUDE-VERIFIED", "NO INTERMEDIARY"];
+const MARQUEE = ["ARC NETWORK", "USDC NATIVE", "SUB-SECOND FINALITY", "$0.01 FEES", "AI-VERIFIED", "NO INTERMEDIARY"];
 
 export default function Home() {
   useReveal();
@@ -51,7 +50,7 @@ export default function Home() {
         <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
           <Logo size={24} withText />
           <div className="flex items-center gap-2.5">
-            <ThemeToggle />
+            <Link to="/docs" className="mono hidden text-xs text-grey-l hover:text-white sm:inline">Docs</Link>
             <Link to="/tasks" className="btn-primary !px-5 !py-2.5">
               Launch App <ArrowRight size={15} />
             </Link>

--- a/src/routes/Settlement.tsx
+++ b/src/routes/Settlement.tsx
@@ -10,6 +10,7 @@ import { submitDeliverable, verifyTask } from "../lib/api";
 import { coreDeployed } from "../lib/contracts";
 import { ContractsNotice } from "./TaskMarket";
 import { shortAddr, deadlineLabel } from "../lib/utils";
+import { humanizeError } from "../lib/errors";
 import type { Task } from "../lib/types";
 
 export default function Settlement() {
@@ -23,7 +24,7 @@ export default function Settlement() {
       <PageHeader
         eyebrow="Settlement Center"
         title="Verify & settle"
-        sub="Submit a deliverable for an assigned task. Claude scores it against the rubric; escrow releases or the stake is slashed - no human approves."
+        sub="Submit a deliverable for an assigned task. our algorithm scores it against the rubric; escrow releases or the stake is slashed - no human approves."
       />
 
       <div className="mb-7 grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -114,7 +115,7 @@ function SettlementRow({ task }: { task: Task }) {
       setPhase("submitting");
       await submitDeliverable(task.taskId, task.assignedAgent ?? address, deliverable.trim());
       setPhase("scoring");
-      toast.loading("Claude is scoring the deliverable…", { id: task.taskId });
+      toast.loading("Our algorithm is scoring the deliverable…", { id: task.taskId });
       const r = await verifyTask(task.taskId);
       setResult(r);
       setPhase("done");
@@ -123,7 +124,7 @@ function SettlementRow({ task }: { task: Task }) {
       });
     } catch (e) {
       setPhase("idle");
-      toast.error((e as Error).message || "Settlement failed", { id: task.taskId });
+      toast.error(humanizeError(e, "Settlement failed. Please try again."), { id: task.taskId });
     }
   };
 

--- a/src/routes/TaskDetail.tsx
+++ b/src/routes/TaskDetail.tsx
@@ -12,7 +12,7 @@ import { shortAddr, deadlineLabel, timeAgo } from "../lib/utils";
 export default function TaskDetail() {
   const { id } = useParams();
   const { task, bids, isLoading } = useTask(id);
-  const { address } = useWallet();
+  const { address, signer } = useWallet();
   const { agents } = useAgents();
   const { run, loading } = useTx();
 
@@ -92,7 +92,7 @@ export default function TaskDetail() {
                 {bids.length > 0 && (
                   <button
                     onClick={() =>
-                      run(() => awardBid(task.taskId), { pending: "Awarding best bid…", success: "Bid awarded - agent assigned" })
+                      run(() => awardBid(task.taskId, signer), { pending: "Awarding best bid…", success: "Bid awarded - agent assigned" })
                     }
                     disabled={loading}
                     className="btn-primary !py-2"
@@ -102,7 +102,7 @@ export default function TaskDetail() {
                 )}
                 <button
                   onClick={() =>
-                    run(() => cancelTask(task.taskId), { pending: "Cancelling & refunding…", success: "Task cancelled, USDC refunded" })
+                    run(() => cancelTask(task.taskId, signer), { pending: "Cancelling & refunding…", success: "Task cancelled, USDC refunded" })
                   }
                   disabled={loading}
                   className="btn-ghost !py-2"
@@ -167,6 +167,7 @@ export default function TaskDetail() {
 }
 
 function PlaceBid({ taskId, budget }: { taskId: `0x${string}`; budget: number }) {
+  const { signer } = useWallet();
   const { run, loading } = useTx();
   const [amount, setAmount] = useState(String(budget));
   const [etaMin, setEtaMin] = useState("30");
@@ -184,7 +185,7 @@ function PlaceBid({ taskId, budget }: { taskId: `0x${string}`; budget: number })
         </label>
         <button
           onClick={() =>
-            run(() => placeBid(taskId, parseFloat(amount) || 0, (parseInt(etaMin) || 30) * 60), {
+            run(() => placeBid(taskId, parseFloat(amount) || 0, (parseInt(etaMin) || 30) * 60, signer), {
               pending: "Placing bid…",
               success: "Bid placed onchain",
             })


### PR DESCRIPTION
## Summary
- **Fix "connector not connected"** on create-task/bid/register: writes now route through a unified `signer` (passkey Circle → batched gasless userOp; PIN wallet → per-write PIN signature; else injected).
- **Add Circle user-controlled (PIN/email) wallet** as an extra connect option. Backend `/api/uc/*` (entity secret server-only); frontend uses `@circle-fin/w3s-pw-web-sdk`. Verified ARC-TESTNET is supported by the UC wallets API. The PIN ceremony is branded with the Polaris logo, palette, font, and copy.
- **Fix the indexer silently rendering nothing**: `VITE_INDEX_CHUNK_BLOCKS` was `10000`, which hits Arc's hard 10,000-block `eth_getLogs` cap. Now `9000`. This is why no agents/tasks showed.
- **Humanize on-screen errors** (`src/lib/errors.ts`): extracts contract revert reasons, strips raw viem/wagmi noise, maps `require()` strings to plain language. Used in `useTx`, `WalletButton`, `Settlement`.
- **TEE settlement**: kept the working signed-oracle, added an honest "Roadmap: TEE settlement" section to the docs (no fake TEE).
- **README + .env.example**: V2 contract addresses, Vercel + Railway env checklists, new UC vars.

## Proven live on Arc testnet (V2 contracts)
- 5 Circle agents registered (Circle caps agent wallets at 5).
- 15 real tasks posted and **all 15 SETTLED** with onchain attestations (scores 70–95).

## Deploy notes (required for the live app)
- **Vercel:** set `VITE_INDEX_CHUNK_BLOCKS=9000`, V2 contract addresses, `VITE_CIRCLE_UC_APP_ID`, then redeploy.
- **Railway:** set `CIRCLE_UC_API_KEY`, `CIRCLE_UC_ENTITY_SECRET`, `CIRCLE_UC_APP_ID` to enable the PIN-wallet routes.

## Not testable headless
The in-browser PIN ceremony (w3s SDK iframe) needs a real browser + user PIN — built per Circle docs; please verify that one flow in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)