### PR TITLE
Mint ERC-8004 identities from the app, and say when one is impossible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ VITE_WALLETCONNECT_PROJECT_ID=
 # Backend verifier base URL (leave blank to use same-origin /api)
 VITE_API_URL=https://polaris-agent-runtime-production.up.railway.app
 
+# Canonical public URL of this app. Used to build the ERC-8004 registration URI that is
+# written on chain when an agent mints its identity, so it must not be a preview domain.
+# Defaults to the browser's origin. Should match the backend's PUBLIC_APP_URL.
+VITE_PUBLIC_APP_URL=https://polarisswarm.xyz
+
 # Deployed contract addresses (from the Hardhat deploy script output)
 VITE_CONTRACT_USDC_ESCROW=
 VITE_CONTRACT_AGENT_REGISTRY=

--- a/VERCEL_ENV.md
+++ b/VERCEL_ENV.md
@@ -14,9 +14,20 @@ Preview), then redeploy. Build command `npm run build`, output `dist`.
 
 ## Required
 
+> **Do NOT set `VITE_API_URL` here.** Arc and BOT Chain run as separate Railway
+> services, and each network already carries the correct one as its default
+> (`src/lib/networks/`). `VITE_API_URL` is a single global override that wins over
+> those defaults, so setting it points **every** network at one runtime: BOT Chain
+> requests then reach the Arc runtime, which correctly refuses them with a 409, and
+> BOT Chain silently stops working in the deployed app while Arc looks fine. It exists
+> for local development, where one process serves both networks. To override a single
+> network, use `VITE_API_URL_ARC` or `VITE_API_URL_BOTCHAIN_TESTNET`.
+
 ```env
-# Backend (the Railway agent runtime that serves /api/index, subscriptions, etc.)
-VITE_API_URL=https://polaris-agent-runtime-production.up.railway.app
+# Backend: leave unset. Each network's runtime URL is already the default.
+# Override one network only if you must:
+# VITE_API_URL_ARC=https://polaris-agent-runtime-production.up.railway.app
+# VITE_API_URL_BOTCHAIN_TESTNET=https://polaris-bot-runtime-production.up.railway.app
 
 # Arc network
 VITE_ARC_RPC_URL=https://rpc.testnet.arc.network
@@ -28,6 +39,21 @@ VITE_USDC_ADDRESS=0x3600000000000000000000000000000000000000
 # Only the App ID is public; its API key + entity secret stay on Railway.
 VITE_CIRCLE_UC_APP_ID=d600913e-7a3b-51d3-bc63-53f3d01a58e5
 VITE_CIRCLE_CHAIN_PATH=arcTestnet
+```
+
+## Optional — canonical app URL (ERC-8004 identity URIs)
+
+When an agent is registered on a network with ERC-8004 deployed, the app mints the
+agent's identity and writes a registration URI into the registry, permanently. That URI
+is built from this value, falling back to the browser's current origin.
+
+Set it in **Production** so an identity minted from a preview deployment cannot bake a
+`*.vercel.app` preview domain into the chain. It should match the backend's
+`PUBLIC_APP_URL`, so a runtime-minted identity and a UI-minted one describe agents the
+same way.
+
+```env
+VITE_PUBLIC_APP_URL=https://polarisswarm.xyz
 ```
 
 ## Optional — Circle Modular Wallets (passkey, gasless)

--- a/src/hooks/useTx.ts
+++ b/src/hooks/useTx.ts
@@ -15,7 +15,18 @@ export function useTx() {
   const run = useCallback(
     async (
       fn: () => Promise<Hash>,
-      opts: { pending: string; success: string; onDone?: (hash: Hash) => void },
+      opts: {
+        pending: string;
+        success: string;
+        /**
+         * Fallback message when the write fails. Worth overriding when a failure does
+         * not mean what the generic wording implies: a best-effort follow-up step can
+         * fail after the main transaction already succeeded, and "Transaction failed"
+         * would wrongly suggest the whole thing was rolled back.
+         */
+        error?: string;
+        onDone?: (hash: Hash) => void;
+      },
     ) => {
       setLoading(true);
       const toastId = toast.loading(opts.pending);
@@ -35,7 +46,7 @@ export function useTx() {
         if (isUserRejection(err)) {
           toast.error("Cancelled.", { id: toastId });
         } else {
-          toast.error(humanizeError(err, "Transaction failed. Please try again."), { id: toastId });
+          toast.error(humanizeError(err, opts.error ?? "Transaction failed. Please try again."), { id: toastId });
           console.error(err);
         }
         return null;

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -169,6 +169,20 @@ export const RECURRING_MARKET_ABI = parseAbi([
   "function getPlan(bytes32) view returns (address requester, address agent, uint256 perDelivery, uint256 price, uint32 total, uint32 done, uint256 escrowed, uint256 minReputation, uint8 status)",
 ]);
 
+/**
+ * ERC-8004 identity registry, trimmed to what the app calls.
+ *
+ * `register` mints to `msg.sender`, which is exactly why this belongs in the
+ * frontend: the identity has to be owned by the agent's own wallet, and at
+ * registration time that wallet is the one connected. Nothing else can mint it on
+ * the agent's behalf.
+ */
+export const ERC8004_IDENTITY_ABI = parseAbi([
+  "function register(string agentURI) returns (uint256 agentId)",
+  "function ownerOf(uint256 tokenId) view returns (address)",
+  "event Registered(uint256 indexed agentId, string agentURI, address indexed owner)",
+]);
+
 export const SUBSCRIPTION_MANAGER_ABI = parseAbi([
   "function createSubscription(bytes32 subId, address agent, uint256 perDeliveryUsdc, uint32 totalDeliveries, (string title, string brief, string rubric, string taskType, string schedule) meta)",
   "function cancelSubscription(bytes32 subId)",

--- a/src/lib/networks/apiBase.ts
+++ b/src/lib/networks/apiBase.ts
@@ -7,8 +7,17 @@
  */
 const ENV = (import.meta as { env?: Record<string, string | undefined> }).env ?? {};
 
-/** `VITE_API_URL_<KEY>` (one network) > `VITE_API_URL` (all networks, used by the
- *  local preview where a single process serves both) > the deployed default. */
+/**
+ * `VITE_API_URL_<KEY>` (one network) > `VITE_API_URL` (ALL networks) > the deployed
+ * default for this network.
+ *
+ * The middle rung is a footgun in production and deliberately documented as such in
+ * VERCEL_ENV.md: it overrides every network's own correct default, so setting it on a
+ * deployment where Arc and BOT Chain run as separate services sends BOT Chain traffic
+ * to the Arc runtime, which refuses it with a 409 while Arc keeps working. It is kept
+ * only because local development runs ONE process that serves both networks, which is
+ * exactly the case where a single global base is right.
+ */
 export function apiBase(key: string, deployed: string): string {
   return ENV[`VITE_API_URL_${key}`] || ENV.VITE_API_URL || deployed;
 }

--- a/src/lib/tx.ts
+++ b/src/lib/tx.ts
@@ -1,5 +1,6 @@
 import {
   readContract,
+  simulateContract,
   writeContract,
   waitForTransactionReceipt,
   switchChain,
@@ -22,6 +23,7 @@ import {
   SUBSCRIPTION_MANAGER_ABI,
   DISPUTE_MANAGER_ABI,
   RECURRING_MARKET_ABI,
+  ERC8004_IDENTITY_ABI,
 } from "./contracts";
 import { circleWrite, type CircleSession } from "./circleWallet";
 import { ucWrite, type UcSession } from "./circleUserWallet";
@@ -237,6 +239,97 @@ export async function registerAgent(
     circle,
     network,
   );
+}
+
+/**
+ * Mint this wallet's ERC-8004 identity.
+ *
+ * WHY THIS IS A FRONTEND CONCERN. The registry's `register` mints to `msg.sender`, so
+ * the identity can only be created by the agent's own wallet. The runtime mints for the
+ * agents whose keys it holds, but an agent registered here belongs to the user's wallet
+ * and nothing in the backend can ever mint for it. Without this, every agent registered
+ * through the UI stayed permanently identity-less, which defeats the point of a registry
+ * whose whole premise is that any application can read an agent's identity.
+ *
+ * Deliberately NOT batched with `registerAgent`. An identity is portable reputation, not
+ * a precondition for earning, so a failure here must never roll back a staked
+ * registration. Callers treat it as best-effort and follow-up.
+ */
+export async function mintAgentIdentity(
+  wallet: Address,
+  circle?: Signer,
+  network?: NetworkId,
+): Promise<Hash> {
+  const id = resolveNetwork(network);
+  const registry = getNetwork(id).erc8004?.identity;
+  if (!registry) throw new Error("ERC-8004 is not deployed on this network.");
+  return run(
+    [
+      {
+        address: registry as Address,
+        abi: ERC8004_IDENTITY_ABI,
+        functionName: "register",
+        args: [identityUri(wallet)],
+      },
+    ],
+    circle,
+    network,
+  );
+}
+
+/**
+ * Can this wallet actually be given an ERC-8004 identity?
+ *
+ * The registry `_safeMint`s an ERC-721, so a contract wallet that does not implement
+ * `onERC721Received` can never hold one: the mint reverts with `ERC721InvalidReceiver`.
+ * Several ERC-4337 accounts on BOT Chain were deployed by a factory that predates the
+ * receiver hook, and they are permanently in that state.
+ *
+ * Rather than hardcode a bytecode heuristic, this simulates the real call. That catches
+ * this cause and any future one, and it is what lets the UI explain why an agent cannot
+ * be given an identity instead of offering a button that reverts with an opaque custom
+ * error after the user has paid for the attempt.
+ */
+export async function canMintAgentIdentity(
+  wallet: Address,
+  network?: NetworkId,
+): Promise<{ ok: boolean; reason?: string }> {
+  const id = resolveNetwork(network);
+  const net = getNetwork(id);
+  const registry = net.erc8004?.identity;
+  if (!registry) return { ok: false, reason: "ERC-8004 is not deployed on this network." };
+  try {
+    await simulateContract(wagmiConfig, {
+      address: registry as Address,
+      abi: ERC8004_IDENTITY_ABI,
+      functionName: "register",
+      args: [identityUri(wallet)],
+      account: wallet,
+      chainId: net.chainId,
+    });
+    return { ok: true };
+  } catch (e) {
+    const msg = (e as Error)?.message ?? "";
+    if (/ERC721InvalidReceiver/i.test(msg)) {
+      return {
+        ok: false,
+        reason:
+          "This agent is a smart account that cannot receive an ERC-721, so the identity registry cannot mint to it. Accounts created by the current factory accept one.",
+      };
+    }
+    return { ok: false, reason: "The identity registry would reject this mint." };
+  }
+}
+
+/** The standard's registration file: a resolvable URI describing the agent. */
+function identityUri(wallet: Address): string {
+  const base = (import.meta.env.VITE_PUBLIC_APP_URL || window.location.origin).replace(/\/$/, "");
+  return `${base}/agent/${wallet}`;
+}
+
+/** True when this network has an ERC-8004 identity registry to mint into. */
+export function erc8004Deployed(network?: NetworkId): boolean {
+  return Boolean(getNetwork(resolveNetwork(network)).erc8004?.identity);
 }
 
 export async function setAgentOnline(

--- a/src/routes/AgentDetail.tsx
+++ b/src/routes/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ShieldCheck, Clock, FileCheck2, Plus, Power, Banknote, Briefcase, Globe, Repeat, Flag, Fingerprint, ExternalLink } from "lucide-react";
 import { AppShell } from "../components/shell/AppShell";
@@ -13,7 +13,7 @@ import RatingsPanel from "../components/RatingsPanel";
 import { useWallet } from "../context/WalletProvider";
 import { useTx } from "../hooks/useTx";
 import { useAgent } from "../lib/onchain";
-import { addStake, withdrawStake, setAgentOnline, hireAgent, newTaskId } from "../lib/tx";
+import { addStake, withdrawStake, setAgentOnline, hireAgent, newTaskId, mintAgentIdentity, canMintAgentIdentity, erc8004Deployed } from "../lib/tx";
 import { explorerAddr } from "../lib/chain";
 import { shortAddr, timeAgo, deadlineLabel, fmtDate, isDone } from "../lib/utils";
 import type { Task } from "../lib/types";
@@ -316,9 +316,52 @@ function OwnerActions({ agent, signer }: { agent: import("../lib/types").Agent; 
   const { symbol } = useAsset();
   const { run, loading } = useTx();
   const [amount, setAmount] = useState("100");
+  // An agent registered before the app minted identities, or by a script, has none.
+  // Only this wallet can fix that (`register` mints to msg.sender), so the control has
+  // to live here rather than anywhere in the backend. Whether it CAN be fixed is a
+  // separate question: a smart account without `onERC721Received` can never hold the
+  // registry's ERC-721, and saying so is more useful than a button that reverts.
+  const needsIdentity = erc8004Deployed() && !agent.erc8004Id;
+  const [mintable, setMintable] = useState<{ ok: boolean; reason?: string } | null>(null);
+  useEffect(() => {
+    if (!needsIdentity) return;
+    let alive = true;
+    canMintAgentIdentity(agent.wallet).then((r) => alive && setMintable(r));
+    return () => {
+      alive = false;
+    };
+  }, [needsIdentity, agent.wallet]);
   return (
     <Panel title="Manage your agent">
       <div className="flex flex-col gap-3">
+        {needsIdentity && mintable?.ok === true && (
+          <div className="rounded-[4px] border border-primary/25 bg-primary/8 p-2.5">
+            <p className="mb-2 text-[11px] leading-relaxed text-muted-foreground">
+              This agent has no ERC-8004 identity yet. Minting one gives it a portable id
+              that any other application can read, independently of Polaris.
+            </p>
+            <button
+              onClick={() =>
+                run(() => mintAgentIdentity(agent.wallet, signer), {
+                  pending: "Minting the ERC-8004 identity…",
+                  success: "ERC-8004 identity minted",
+                })
+              }
+              disabled={loading}
+              className="tool-btn-primary w-full"
+            >
+              <Fingerprint className="h-3.5 w-3.5" /> Mint ERC-8004 identity
+            </button>
+          </div>
+        )}
+        {needsIdentity && mintable?.ok === false && (
+          <div className="rounded-[4px] border border-border bg-muted p-2.5">
+            <div className="field-label mb-1 flex items-center gap-1.5">
+              <Fingerprint className="h-3 w-3" /> No ERC-8004 identity
+            </div>
+            <p className="text-[11px] leading-relaxed text-muted-foreground">{mintable.reason}</p>
+          </div>
+        )}
         <label className="block">
           <div className="field-label mb-2">Add stake ({symbol})</div>
           <input type="number" min="1" className="field" value={amount} onChange={(e) => setAmount(e.target.value)} />

--- a/src/routes/Agents.tsx
+++ b/src/routes/Agents.tsx
@@ -10,7 +10,7 @@ import ContractsNotice from "../components/ContractsNotice";
 import ImagePicker from "../components/ImagePicker";
 import { useAgents } from "../lib/onchain";
 import { useTx } from "../hooks/useTx";
-import { registerAgent, setAgentOnline } from "../lib/tx";
+import { canMintAgentIdentity, erc8004Deployed, mintAgentIdentity, registerAgent, setAgentOnline } from "../lib/tx";
 import { uploadAgentMeta, uploadAsset } from "../lib/api";
 import { coreDeployed } from "../lib/contracts";
 import { useAsset } from "../hooks/useAsset";
@@ -116,6 +116,22 @@ function RegisterForm() {
     if (hash) {
       if (image) await uploadAsset(address, image); // avatar keyed by agent wallet
       if (endpoint.trim()) await uploadAgentMeta(address, { endpoint: endpoint.trim(), auth: auth.trim() || undefined });
+      // Mint the portable ERC-8004 identity as a follow-up, never as part of the
+      // registration batch: `register` mints to msg.sender so only this wallet can do
+      // it, but an identity is portable reputation rather than a precondition for
+      // earning, and a failure here must not undo a staked registration.
+      // Simulate before asking the user to sign. A wallet that cannot receive an
+      // ERC-721 would revert with an opaque custom error, and charging them gas to
+      // discover that after they have already staked would be indefensible.
+      if (erc8004Deployed() && (await canMintAgentIdentity(address)).ok) {
+        await run(() => mintAgentIdentity(address, signer), {
+          pending: "Minting the agent's ERC-8004 identity…",
+          success: "ERC-8004 identity minted",
+          // The agent is already registered and can earn; say so rather than
+          // implying the whole registration failed.
+          error: "Registered, but the ERC-8004 identity could not be minted. You can mint it later from the agent's page.",
+        });
+      }
     }
     setName("");
     setCaps([]);


### PR DESCRIPTION
Indexing the registry's `Registered` event (previous PR) made every existing identity visible, but it could not create the missing ones. On BOT Chain only **3 of 7** registered agents had an identity, and the reason was structural.

## Why the backend could never fix this

`register` mints to `msg.sender`. An agent registered through the UI belongs to the user's wallet, so nothing in the backend can ever mint for it — the runtime only mints for the two agents whose keys it holds. Every agent a human registered was permanently identity-less. For a registry whose whole premise is that any application can read an agent's identity, that is the difference between a deployed address and a working standard.

## The mint moves to where the agent's wallet is

- **On registration**: registering an agent on a network with ERC-8004 deployed now mints its identity as a follow-up step, **never inside the registration batch**. An identity is portable reputation, not a precondition for earning, and a failure must not roll back a staked registration. `useTx` gained an `error` override so that case reads "registered, but the identity could not be minted" rather than the generic "transaction failed", which would wrongly imply the stake was lost.
- **After the fact**: an agent that already exists without one gets a mint control on its own page, so the gap is self-healing rather than permanent.

## Some agents can never hold one, and the UI says so

The registry `_safeMint`s an ERC-721, and several ERC-4337 accounts on BOT Chain were deployed by a factory predating `onERC721Received`. Minting to them reverts with `ERC721InvalidReceiver`.

Rather than a bytecode heuristic, both call sites **simulate the real call first**. That catches this cause and any future one, and it means the registration flow never asks a user to sign a mint that cannot succeed.

Confirmed against the live registry with `eth_call`, which executes the real function body:

```
AA-Agent      0x1feD619A…  contract  REVERT ERC721InvalidReceiver(0x1feD619A…)
AA-Agent      0x7cBcbDfD…  contract  REVERT ERC721InvalidReceiver(0x7cBcbDfD…)
Bohr-Writer   0x1600fb54…  contract  REVERT ERC721InvalidReceiver(0x1600fb54…)
AA-Agent      0x6CE29B8B…  contract  ok -> would mint #8      (current factory)
Bohr-Research 0x5B99A8e3…  EOA       ok -> would mint #8
```

## A deployment trap closed along the way

`VITE_API_URL` is a single global override that beats every network's own default, so setting it points all networks at one runtime: BOT Chain requests reach the Arc runtime, which correctly refuses them with a 409, and **BOT Chain silently stops working while Arc looks fine**. Production does not set it and is unaffected, but `VERCEL_ENV.md` instructed setting it. The docs now say not to and name the per-network overrides instead. `VITE_PUBLIC_APP_URL` is documented too, since the identity URI is written on chain and must not bake in a preview domain.

## Verification

`tsc -b`, `eslint src`, production build, 50 backend + 85 contract tests — all clean. The on-chain behaviour is proven by the `eth_call` probe above rather than by mocks. The mint controls are owner-gated, so they cannot be exercised in a headless browser without a connected wallet; they are covered by type-checking and by that live simulation of the underlying call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)