### PR TITLE
Merge mintability cache writes instead of replacing them

### DIFF
--- a/server/erc8004.js
+++ b/server/erc8004.js
@@ -111,7 +111,7 @@ function mintableStore(ctx) {
   });
 }
 
-function loadMintable(ctx) {
+function readMintableFile(ctx) {
   try {
     return JSON.parse(fs.readFileSync(mintableStore(ctx), "utf8"));
   } catch {
@@ -119,11 +119,42 @@ function loadMintable(ctx) {
   }
 }
 
-function saveMintable(ctx, map) {
+/**
+ * In-memory view of the cache, per chain.
+ *
+ * The overview probes every identity-less agent concurrently, and the first version of
+ * this read the whole JSON file, added one key, and wrote the file back. Four parallel
+ * probes therefore each wrote a map containing only their own result and the last one won:
+ * three verdicts were computed, cached in nobody's copy, and lost. Production showed it
+ * plainly — one agent carried a verdict and three stayed unknown.
+ *
+ * So writes merge instead of replacing, and the merged map is kept in memory so repeat
+ * reads cost nothing.
+ */
+const mintableCache = new Map(); // chainId -> { [wallet]: verdict }
+
+function loadMintable(ctx) {
+  let map = mintableCache.get(ctx.chainId);
+  if (!map) {
+    map = readMintableFile(ctx);
+    mintableCache.set(ctx.chainId, map);
+  }
+  return map;
+}
+
+/**
+ * Record one verdict. Merges over whatever is already on disk, so a concurrent writer's
+ * entry survives, and keeps the in-memory map in step.
+ */
+function recordMintable(ctx, wallet, verdict) {
+  const map = loadMintable(ctx);
+  map[wallet] = verdict;
   try {
-    fs.writeFileSync(mintableStore(ctx), JSON.stringify(map));
+    const merged = { ...readMintableFile(ctx), ...map };
+    mintableCache.set(ctx.chainId, merged);
+    fs.writeFileSync(mintableStore(ctx), JSON.stringify(merged));
   } catch {
-    /* best-effort cache */
+    /* best-effort cache; the in-memory map still holds the verdict for this process */
   }
 }
 
@@ -191,8 +222,7 @@ export async function identityMintability(ctx, wallet) {
     verdict = isInvalidReceiver(e) ? "unsupported-receiver" : "rejected";
   }
 
-  cached[key] = verdict;
-  saveMintable(ctx, cached);
+  recordMintable(ctx, key, verdict);
   return verdict;
 }
 

--- a/server/test/erc8004Mintability.test.js
+++ b/server/test/erc8004Mintability.test.js
@@ -96,3 +96,23 @@ test("a verdict is cached, so the same address is probed at most once", async ()
   assert.equal(await identityMintability(second, wallet), "unsupported-receiver");
   assert.equal(calls.length, before, "a cached verdict must not re-probe");
 });
+
+test("concurrent probes all persist: no verdict is lost to a last-writer-wins race", async () => {
+  // The overview probes every identity-less agent at once. The first version of the cache
+  // read the whole file, added one key and wrote the file back, so four parallel probes
+  // each persisted only their own result and three were silently dropped. Production
+  // showed exactly that: one agent carried a verdict and three stayed unknown.
+  const wallets = [
+    "0xa000000000000000000000000000000000000001",
+    "0xa000000000000000000000000000000000000002",
+    "0xa000000000000000000000000000000000000003",
+    "0xa000000000000000000000000000000000000004",
+  ];
+  const ctx = ctxThatReverts(revert(`${SELECTOR}${"0".repeat(64)}`));
+  await Promise.all(wallets.map((w) => identityMintability(ctx, w)));
+
+  const onDisk = JSON.parse(fs.readFileSync(path.join(process.env.POLARIS_STATE_DIR, "erc8004-mintable-968.json"), "utf8"));
+  for (const w of wallets) {
+    assert.equal(onDisk[w], "unsupported-receiver", `${w} must survive the concurrent write`);
+  }
+});


### PR DESCRIPTION
The overview probes every identity-less agent concurrently, and the mintability cache read the whole JSON file, added one key and wrote the file back. Four parallel probes therefore each persisted a map containing only their own result, and the last writer won.

Production showed it immediately after deploy: all four verdicts were computed and the BOT runtime's dashboard displayed them correctly in that process, but only one reached the file. The indexer reads that file to carry the verdict to the peer runtime, so the Arc runtime kept reporting three BOT agents as `pending` — the exact ambiguity this feature exists to remove, reintroduced one layer down.

Writes now merge over what is on disk and keep an in-process map, so repeat reads cost nothing and a concurrent writer's entry survives.

The test fails against the previous implementation (verified by reverting only the implementation and keeping the test), which is the only reason to trust it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)