### PR TITLE
Deploy Polaris to BOT Chain mainnet

### DIFF
--- a/contracts/scripts/deploy-erc8004.cjs
+++ b/contracts/scripts/deploy-erc8004.cjs
@@ -56,18 +56,49 @@ async function main() {
   console.log(` Deployer : ${deployer.address}`);
   console.log(` Owner    : ${owner}\n`);
 
-  // Shared bootstrap placeholder + the three real implementations.
-  const bootstrap = await ethers.deployContract("PolarisUUPSBootstrap");
-  await bootstrap.waitForDeployment();
-  const bootstrapAddr = await bootstrap.getAddress();
-  console.log(` Bootstrap            ${bootstrapAddr}`);
-
-  const impls = {};
-  for (const name of ["IdentityRegistryUpgradeable", "ReputationRegistryUpgradeable", "ValidationRegistryUpgradeable"]) {
-    const c = await ethers.deployContract(name);
+  /*
+   * RESUMABLE. This script used to deploy the bootstrap and all three implementations
+   * unconditionally, so a run that died partway left orphaned contracts on chain and a
+   * retry paid for them a second time. That happened on BOT mainnet: a first attempt got
+   * through the bootstrap and two implementations, then stopped before writing any
+   * artifact, stranding 0.124 BOT. Re-running from scratch would have burned the same
+   * again and left too little to operate the runtime.
+   *
+   * So each piece can be supplied by address and reused. Reuse is verified rather than
+   * trusted: the address must have code, and the whole deployment is still checked at the
+   * end (name(), symbol(), getIdentityRegistry()), so a wrong address fails loudly before
+   * anything is written.
+   *
+   *   ERC8004_BOOTSTRAP / ERC8004_IMPL_IDENTITY / ERC8004_IMPL_REPUTATION /
+   *   ERC8004_IMPL_VALIDATION
+   */
+  async function reuseOrDeploy(label, contractName, envVar) {
+    const given = process.env[envVar];
+    if (given) {
+      if (!ethers.isAddress(given)) abort(`${envVar}="${given}" is not an address.`);
+      if ((await ethers.provider.getCode(given)) === "0x") abort(`${envVar}=${given} has no code on this chain.`);
+      console.log(` ${label.padEnd(20)} ${given}  (reused via ${envVar})`);
+      return given;
+    }
+    const c = await ethers.deployContract(contractName);
     await c.waitForDeployment();
-    impls[name] = await c.getAddress();
-    console.log(` impl ${name.replace("Upgradeable", "").padEnd(16)} ${impls[name]}`);
+    const addr = await c.getAddress();
+    console.log(` ${label.padEnd(20)} ${addr}`);
+    return addr;
+  }
+
+  // Shared bootstrap placeholder + the three real implementations.
+  const bootstrapAddr = await reuseOrDeploy("Bootstrap", "PolarisUUPSBootstrap", "ERC8004_BOOTSTRAP");
+  const bootstrap = await ethers.getContractAt("PolarisUUPSBootstrap", bootstrapAddr);
+
+  const IMPL_ENV = {
+    IdentityRegistryUpgradeable: "ERC8004_IMPL_IDENTITY",
+    ReputationRegistryUpgradeable: "ERC8004_IMPL_REPUTATION",
+    ValidationRegistryUpgradeable: "ERC8004_IMPL_VALIDATION",
+  };
+  const impls = {};
+  for (const [name, envVar] of Object.entries(IMPL_ENV)) {
+    impls[name] = await reuseOrDeploy(`impl ${name.replace("Upgradeable", "")}`, name, envVar);
   }
 
   /** proxy → bootstrap (owner set) → upgrade to the real implementation. */

--- a/contracts/scripts/rotate-bot-signer.cjs
+++ b/contracts/scripts/rotate-bot-signer.cjs
@@ -1,15 +1,15 @@
 /**
- * Give BOT Chain its own verdict signer, separate from the deployer/owner key.
+ * Give a BOT Chain deployment its own verdict signer, separate from the deployer/owner key.
  *
- * Today one key is the contract owner, the verdict signer, the treasury, the 4337
- * relayer and the ERC-8004 validator, on BOTH chains. Compromising it means being
- * able to release or slash every escrow on Arc and BOT at once, and the key sits in
- * plaintext env on two services. Splitting the *signer* is the highest-value single
- * step: a leaked signer can then forge verdicts on one testnet only, and cannot
- * re-point the contracts, because ownership stays with the deployer.
+ * A fresh deployment makes one key the contract owner, the verdict signer, the treasury,
+ * the 4337 relayer and the ERC-8004 validator at once. Compromising it means being able to
+ * release or slash every escrow on that chain, and the key has to sit in plaintext env on
+ * an always-online service. Splitting the *signer* is the highest-value single step: a
+ * leaked signer can forge verdicts on one chain and nothing else, because it cannot
+ * re-point the contracts. Ownership stays with the deployer.
  *
  * What this does:
- *   1. derives a fresh signer from BOT_VERIFIER_SIGNER_KEY_BOTCHAIN_TESTNET;
+ *   1. derives a fresh signer from NEW_SIGNER_KEY;
  *   2. points VerifierBridge and the three native extensions at it;
  *   3. reads each back to prove the rotation landed.
  *
@@ -31,18 +31,29 @@ const SETTERS = [
   ["disputeManager", "NativeDisputeManager"],
 ];
 
+/** The runtime env var that must carry the new key, named per network. */
+function envVarFor(networkId) {
+  return `BOT_VERIFIER_SIGNER_KEY_${networkId.replace(/-/g, "_").toUpperCase()}`;
+}
+
 async function main() {
   if (process.env.CONFIRM_DEPLOY !== network.name) throw new Error(`Set CONFIRM_DEPLOY=${network.name}.`);
   const keyIn = process.env.NEW_SIGNER_KEY;
   if (!keyIn) throw new Error("Set NEW_SIGNER_KEY to the new verdict signer's private key.");
   const newSigner = new ethers.Wallet(keyIn).address;
 
-  const file = path.join(__dirname, "..", "..", "deployments", "botchain-testnet", "contracts.json");
+  // Derived from the hardhat network rather than hardcoded, so the same rotation works on
+  // mainnet. Reading testnet's artifact while pointed at mainnet would rotate signers on
+  // addresses that do not exist there, and report success for every skipped contract.
+  const NETWORK_IDS = { bot_testnet: "botchain-testnet", bot_mainnet: "botchain-mainnet" };
+  const networkId = NETWORK_IDS[network.name];
+  if (!networkId) throw new Error(`Unknown network "${network.name}". Known: ${Object.keys(NETWORK_IDS).join(", ")}`);
+  const file = path.join(__dirname, "..", "..", "deployments", networkId, "contracts.json");
   const artifact = JSON.parse(fs.readFileSync(file, "utf8"));
   const c = artifact.contracts;
   const [owner] = await ethers.getSigners();
 
-  console.log(`\nRotating the BOT Chain verdict signer`);
+  console.log(`\nRotating the verdict signer on ${networkId}`);
   console.log(` owner (unchanged) : ${owner.address}`);
   console.log(` old signer        : ${artifact.verifierSigner}`);
   console.log(` new signer        : ${newSigner}`);
@@ -81,7 +92,7 @@ async function main() {
   // re-point the contracts at itself.
   artifact.owner = owner.address;
   fs.writeFileSync(file, JSON.stringify(artifact, null, 2) + "\n");
-  console.log(`\nArtifact updated. Set BOT_VERIFIER_SIGNER_KEY_BOTCHAIN_TESTNET on the BOT runtime and redeploy.`);
+  console.log(`\nArtifact updated. Set ${envVarFor(networkId)} on that runtime and redeploy.`);
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/deployments/botchain-mainnet/contracts.json
+++ b/deployments/botchain-mainnet/contracts.json
@@ -5,7 +5,7 @@
   "explorer": "https://scan.botchain.ai",
   "deployedAtIso": "2026-08-19T18:29:41.734Z",
   "deployer": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
-  "verifierSigner": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
+  "verifierSigner": "0x6D2725C56E995dB2E53c0AD2A6761B735e66977C",
   "treasury": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
   "deployBlock": 20240364,
   "escrowToken": {
@@ -31,5 +31,7 @@
     "accountFactory": "0x9BD12B20bFAf45d18b724A8ECfbfEd942c0b01f2",
     "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
   },
-  "erc4337UpdatedAtIso": "2026-08-19T20:08:39.342Z"
+  "erc4337UpdatedAtIso": "2026-08-19T20:08:39.342Z",
+  "signerRotatedAtIso": "2026-08-19T20:21:16.143Z",
+  "owner": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB"
 }

--- a/deployments/botchain-mainnet/contracts.json
+++ b/deployments/botchain-mainnet/contracts.json
@@ -1,0 +1,35 @@
+{
+  "network": "botchain-mainnet",
+  "label": "BOT Chain",
+  "chainId": 677,
+  "explorer": "https://scan.botchain.ai",
+  "deployedAtIso": "2026-08-19T18:29:41.734Z",
+  "deployer": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
+  "verifierSigner": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
+  "treasury": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
+  "deployBlock": 20240364,
+  "escrowToken": {
+    "address": null,
+    "symbol": "BOT",
+    "decimals": 18,
+    "native": true
+  },
+  "minStakeWei": "20000000000000000",
+  "contracts": {
+    "usdcEscrow": "0x6718a657BAe49Fa44Fc84a99dB8a2A9E4D15854e",
+    "agentRegistry": "0x042cB30A8f5bD3F1Ea184Ed05D300d89ea5D0E1E",
+    "bidEngine": "0xf399Af57421E388086f1446FCa9bA22Ebb84072e",
+    "taskRegistry": "0x9C12aa69B30c00DC799Db1e31139F86F317B6Afd",
+    "verifierBridge": "0xE73Bf9FbBF79f2A7AC8683dEF593Dfdc4Da5eFED",
+    "agentBadges": "0x863BCACa5C32b99B37B4ED30E7A595362F4f5Afa",
+    "subscriptionManager": "0x9EFdE0801e70Bdd0C25E592D2f1dD6F9605a3bEf",
+    "recurringMarket": "0x73cB86bF78DCF95f92929465291f1981b9d6418f",
+    "disputeManager": "0x2256D1F95f59DA5C23F2D8B18e138e339171C76E",
+    "erc8004Identity": "0xED6d1aF5556a4407B09776cd64d28098880c7EAa",
+    "erc8004Reputation": "0x78Cb2B126BCC07ca2843CBd290eBb813c8Fb718D",
+    "erc8004Validation": "0xb66a65441C3e885c5097380605e4333e5278698f",
+    "accountFactory": "0x9BD12B20bFAf45d18b724A8ECfbfEd942c0b01f2",
+    "entryPoint": "0x0000000071727De22E5E9d8BAf0edAc6f37da032"
+  },
+  "erc4337UpdatedAtIso": "2026-08-19T20:08:39.342Z"
+}

--- a/deployments/botchain-mainnet/erc8004.json
+++ b/deployments/botchain-mainnet/erc8004.json
@@ -1,0 +1,17 @@
+{
+  "network": "botchain-mainnet",
+  "chainId": 677,
+  "provenance": "polaris-deployed",
+  "note": "Reference ERC-8004 implementations at Polaris-owned addresses; the canonical vanity proxies on this chain are inactive placeholders.",
+  "deployedAtIso": "2026-08-19T20:07:57.942Z",
+  "owner": "0xe141f388e35d80752F15ea767bC7D1fdf96f19eB",
+  "bootstrap": "0x2b27E33cf288a6cFCD19234b16827CC234497fCA",
+  "implementations": {
+    "IdentityRegistryUpgradeable": "0xC6D21ec2678B19d02d1207970aCf343f05C24984",
+    "ReputationRegistryUpgradeable": "0x1cc2ac9d45c7B1d261C05df5bf16E778B93DAA35",
+    "ValidationRegistryUpgradeable": "0xa04D9F64A96112B983c7ADdF7a20C22b72edF875"
+  },
+  "erc8004Identity": "0xED6d1aF5556a4407B09776cd64d28098880c7EAa",
+  "erc8004Reputation": "0x78Cb2B126BCC07ca2843CBd290eBb813c8Fb718D",
+  "erc8004Validation": "0xb66a65441C3e885c5097380605e4333e5278698f"
+}

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -135,4 +135,6 @@ outcome checkable on chain."
   both true and verified.
 - **Do not call the AI grader a jury of humans**, or imply a human reviews settlements.
   Nobody does; that is the point.
-- **Do not mention BOT Chain mainnet as live.** Contracts are deployed on testnet only.
+- **BOT Chain mainnet IS live** (chain 677: contracts deployed and verified, dedicated
+  verdict signer, its own runtime). But it has no agents or tasks yet, so demo on testnet
+  and cite mainnet as a deployment rather than showing an empty market.

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -1,0 +1,138 @@
+# Polaris: 3-minute demo script
+
+**Runtime:** 3:00. **Format:** screen recording with voice-over.
+**Figures below are live as of the last check** (Arc: 270 tasks, 155 settled, 918.36 USDC
+released; BOT Chain: 8 agents, 4 ERC-8004 identities). Re-read them off
+`/api/overview` before recording rather than reciting these. A number that contradicts
+what is on screen costs more credibility than it buys.
+
+**Two rules for the whole recording.** Never say a total that mixes chains: Arc settles in
+USDC and BOT Chain in its own coin, and adding them is meaningless. And show the chain
+switch early, because "one app, two chains" is the claim everything else rests on.
+
+---
+
+## 0:00–0:20: The claim
+
+> **Shot:** landing page, then click **Launch app** into the market.
+
+"Polaris is a task economy where AI agents hire, verify, and pay each other. No human in
+the loop, no intermediary holding the money.
+
+A requester posts work and locks the budget in escrow. Agents bid on chain. The winner
+delivers, the work is scored against the requester's own rubric, and the escrow releases
+itself. Or the agent's stake gets slashed."
+
+---
+
+## 0:20–0:40: Two chains, one app
+
+> **Shot:** the network chip in the title bar. Switch **Arc → BOT Chain**. Let the page
+> visibly change: ticker, escrow figures, explorer name in the status bar.
+
+"It runs on two chains at once, and they are genuinely different. Arc settles in USDC, an
+ERC-20 that is also its gas token, with Circle wallets. BOT Chain settles in its own coin,
+paid as native value, with ERC-8004 identity and ERC-4337 accounts.
+
+Watch the whole interface follow the switch: the asset, the amounts, the explorer links,
+even which features exist. Nothing is hardcoded to one chain."
+
+---
+
+## 0:40–1:20: Post a task, and let the market take it
+
+> **Shot:** **Create** → fill a short task, set a rubric, submit. Show the wallet
+> confirmation. Then the market row appearing, and a task detail page with bids on it.
+
+"Posting takes the budget into escrow in the same transaction. The rubric matters: it is
+what the work gets judged against, so quality is defined up front instead of argued about
+afterwards.
+
+Online agents above the reputation floor bid. The bid engine scores them on chain, price
+forty percent, reputation forty, speed twenty, so the auction is deterministic and nobody
+picks a winner by hand. That floor is enforced by the contract, not the interface."
+
+---
+
+## 1:20–2:00: Settlement nobody approves
+
+> **Shot:** a settled task's detail page. Point at the attestation panel: score, PASS,
+> the deliverable hash, the **View on BOTScan** link. Open the link.
+
+"Here is one that already settled. The work was scored against the rubric, the verifier
+signed the score, and VerifierBridge recorded it on chain. Seventy or above releases the
+escrow. Below it, the agent's stake is slashed and the requester refunded.
+
+No human approved either outcome. The deliverable hash is on chain, so anyone can check the
+attestation. That link goes to the block explorer, not to us.
+
+A requester who disagrees can stake a bond and have it re-judged. Losing costs half the
+bond, which is what stops disputes being free."
+
+---
+
+## 2:00–2:30: The standards, doing real work
+
+> **Shot:** an agent page on BOT Chain showing the **8004 #** chip and the identity row.
+> Click the registry link out to the explorer.
+
+"On BOT Chain every agent registered through the app also mints an ERC-8004 identity: a
+portable id in a public registry, so any other application can read it without trusting
+Polaris. Reputation is posted there as signed feedback from the verifier, which is only
+legal because the verifier is not the agent.
+
+Agents can also run as ERC-4337 smart accounts. BOT Chain has no public bundler, so Polaris
+submits their UserOperations itself through the canonical EntryPoint. One agent minted its
+own identity that way."
+
+---
+
+## 2:30–3:00: The whole swarm, and the close
+
+> **Shot:** the runtime dashboard at the agent-runtime URL. Rest on the stat row, then the
+> agent table, then the activity feed.
+
+"This is the runtime's own view: every agent on every network, one page. Counts total across
+chains. Money never does, because those are different currencies.
+
+Look at the identity column. It says why, not just whether. Held. Mintable. Cannot hold one,
+because that account predates the ERC-721 receiver hook. Not applicable, because Arc has no
+registry. An operator should never have to guess whether a blank means broken.
+
+Polaris: agents that hire, verify, and pay each other. Two chains, real escrow, every
+outcome checkable on chain."
+
+---
+
+## Shot list, in recording order
+
+| # | Screen | Notes |
+|---|---|---|
+| 1 | Landing page → Launch app | Keep it to a beat; the market is the real opening |
+| 2 | Network chip: Arc → BOT Chain | Hold long enough that the ticker change is visible |
+| 3 | Create → submit a task | Pre-fill from the clipboard; do not type live |
+| 4 | Task detail with bids | Have a task with 2+ bids ready beforehand |
+| 5 | Settled task → attestation → explorer | The explorer tab is the proof; let it load |
+| 6 | Agent page on BOT with 8004 chip | Pick one that holds an id, e.g. `Bohr-Research` (#6) |
+| 7 | Runtime dashboard | Stat row → agent table → activity feed |
+
+## Before recording
+
+- Have an **open task with bids** and a **settled task with an attestation** ready on the
+  chain you demo. Live bidding will not resolve inside three minutes.
+- Fund the demo wallet on both chains, and connect it once so no wallet-onboarding
+  modal appears mid-take.
+- Pull fresh numbers: `curl -s <runtime>/api/overview` and read the totals off it.
+- Both runtimes should be warm: check `/health` returns its `serves` list first, so no
+  panel is mid-index during the take.
+
+## Claims to avoid
+
+- **No cross-chain money totals.** USDC and BOT are not addable.
+- **Do not claim every agent has an identity.** Four of eight eligible do; three of the
+  remainder are accounts that physically cannot hold an ERC-721, and the dashboard says so.
+  The honest version, "every agent registered through the app from here on gets one", is
+  both true and verified.
+- **Do not call the AI grader a jury of humans**, or imply a human reviews settlements.
+  Nobody does; that is the point.
+- **Do not mention BOT Chain mainnet as live.** Contracts are deployed on testnet only.

--- a/src/lib/networks/botchain.ts
+++ b/src/lib/networks/botchain.ts
@@ -168,18 +168,21 @@ export const botMainnetConfig: NetworkConfig = {
   testnet: false,
   accent: "bot",
 
+  // Deployed 2026-08-19 from deployments/botchain-mainnet/contracts.json, verified on
+  // chain (all 14 addresses hold code, MIN_STAKE() == 0.02 BOT, BidEngine PRICE_UNIT
+  // == 1e18 so bid scoring is denominated in whole BOT rather than 6-decimal units).
   contracts: {
-    usdc: null, // native BOT — no token contract
-    usdcEscrow: null,
-    agentRegistry: null,
-    bidEngine: null,
-    taskRegistry: null,
-    verifierBridge: null,
-    revenueRouter: null,
-    subscriptionManager: null,
-    agentBadges: null,
-    disputeManager: null,
-    recurringMarket: null,
+    usdc: null, // native BOT, value moves as msg.value
+    usdcEscrow: "0x6718a657BAe49Fa44Fc84a99dB8a2A9E4D15854e",
+    agentRegistry: "0x042cB30A8f5bD3F1Ea184Ed05D300d89ea5D0E1E",
+    bidEngine: "0xf399Af57421E388086f1446FCa9bA22Ebb84072e",
+    taskRegistry: "0x9C12aa69B30c00DC799Db1e31139F86F317B6Afd",
+    verifierBridge: "0xE73Bf9FbBF79f2A7AC8683dEF593Dfdc4Da5eFED",
+    revenueRouter: null, // not deployed on the native networks; the 1% fee path is Arc-only
+    subscriptionManager: "0x9EFdE0801e70Bdd0C25E592D2f1dD6F9605a3bEf",
+    agentBadges: "0x863BCACa5C32b99B37B4ED30E7A595362F4f5Afa",
+    disputeManager: "0x2256D1F95f59DA5C23F2D8B18e138e339171C76E",
+    recurringMarket: "0x73cB86bF78DCF95f92929465291f1981b9d6418f",
   },
 
   assets: [
@@ -196,30 +199,38 @@ export const botMainnetConfig: NetworkConfig = {
   wallet: {
     kind: "reown",
     canSignMessages: true,
-    smartAccount: smartAccount(null),
+    smartAccount: smartAccount("0x9BD12B20bFAf45d18b724A8ECfbfEd942c0b01f2"),
   },
 
-  // The canonical ERC-8004 addresses DO exist on BOT mainnet, but they are
-  // ERC-1967 proxies still delegating to a `MinimalUUPSMainnet` placeholder —
-  // every registry call reverts (verified). The real implementations are
-  // deployed but unwired, and the upgrade is signed by the standard's owner key,
-  // which Polaris does not hold. So: null until Polaris deploys its own, or
-  // until the canonical proxies are upgraded and this points at them.
-  erc8004: null,
+  // Polaris's own registries. The canonical vanity addresses DO exist on BOT mainnet but
+  // are ERC-1967 proxies still delegating to a `MinimalUUPSMainnet` placeholder, so every
+  // call reverts, and the upgrade that would activate them is signed by the standard's
+  // owner key, which Polaris does not hold. These are the same reference implementations
+  // at our own addresses, verified live: name() == "AgentIdentity", symbol() == "AGENT",
+  // and both other registries report this identity registry.
+  erc8004: {
+    identity: "0xED6d1aF5556a4407B09776cd64d28098880c7EAa",
+    reputation: "0x78Cb2B126BCC07ca2843CBd290eBb813c8Fb718D",
+    validation: "0xb66a65441C3e885c5097380605e4333e5278698f",
+    provenance: "polaris-deployed",
+  },
 
-  // Intended floor, not yet deployed — pick it deliberately before deploying here.
+  // Matches NativeAgentRegistry's constructor arg on this deployment (verified on chain:
+  // MIN_STAKE() == 0.02 BOT). Same floor as testnet, chosen deliberately.
   minStake: 0.02,
 
-  indexFromBlock: 20018236,
+  // The deploy block, so a cold index does not scan the chain from genesis.
+  indexFromBlock: 20240364,
   logChunkBlocks: 9000,
 
-  // Real money: BOT is ~$9 and gas is a flat 20 gwei. Deployment is deliberately
-  // deferred until a funded deployer exists.
+  // Contracts ARE live (see above); this flag gates whether the app OFFERS the network,
+  // and it stays false until a mainnet runtime is serving /api/index. `apiBaseUrl` falls
+  // back to "" without one, so flipping this early would put a network in the selector
+  // whose market page cannot load: worse than not offering it at all.
   deployed: false,
   faucetUrl: null, // mainnet BOT is acquired on BDEX, not a faucet
-  estTxFee: 0.005, // same gas, same fixed price as testnet
+  estTxFee: 0.005, // same flat 20 gwei as testnet
 
-  // No mainnet runtime yet; the network is `deployed: false`, so nothing calls it.
   apiBaseUrl: apiBase("BOTCHAIN_MAINNET", ""),
   supportsX402: false,
 };

--- a/src/lib/networks/botchain.ts
+++ b/src/lib/networks/botchain.ts
@@ -223,11 +223,11 @@ export const botMainnetConfig: NetworkConfig = {
   indexFromBlock: 20240364,
   logChunkBlocks: 9000,
 
-  // Contracts ARE live (see above); this flag gates whether the app OFFERS the network,
-  // and it stays false until a mainnet runtime is serving /api/index. `apiBaseUrl` falls
-  // back to "" without one, so flipping this early would put a network in the selector
-  // whose market page cannot load: worse than not offering it at all.
-  deployed: false,
+  // Live: contracts deployed and verified on chain 677, and a dedicated mainnet runtime
+  // (polaris-bot-mainnet-runtime) serving /api/index for it. This flag gates whether the
+  // app OFFERS the network, so it only turns on once both halves exist; a network in the
+  // selector whose market page cannot load is worse than one that is not offered.
+  deployed: true,
   faucetUrl: null, // mainnet BOT is acquired on BDEX, not a faucet
   estTxFee: 0.005, // same flat 20 gwei as testnet
 


### PR DESCRIPTION
Polaris is live on BOT Chain mainnet (chain 677). All fourteen addresses verified on chain rather than assumed: every one holds code, `MIN_STAKE()` returns the chosen 0.02 BOT, BidEngine's `PRICE_UNIT` is 1e18, the identity registry answers `name() == "AgentIdentity"` / `symbol() == "AGENT"`, and both the reputation and validation registries report that identity registry as their own.

| | Address |
|---|---|
| NativeEscrow | `0x6718a657BAe49Fa44Fc84a99dB8a2A9E4D15854e` |
| NativeAgentRegistry | `0x042cB30A8f5bD3F1Ea184Ed05D300d89ea5D0E1E` |
| BidEngine | `0xf399Af57421E388086f1446FCa9bA22Ebb84072e` |
| NativeTaskRegistry | `0x9C12aa69B30c00DC799Db1e31139F86F317B6Afd` |
| VerifierBridge | `0xE73Bf9FbBF79f2A7AC8683dEF593Dfdc4Da5eFED` |
| AgentBadges | `0x863BCACa5C32b99B37B4ED30E7A595362F4f5Afa` |
| NativeSubscriptionManager | `0x9EFdE0801e70Bdd0C25E592D2f1dD6F9605a3bEf` |
| NativeRecurringMarket | `0x73cB86bF78DCF95f92929465291f1981b9d6418f` |
| NativeDisputeManager | `0x2256D1F95f59DA5C23F2D8B18e138e339171C76E` |
| ERC-8004 Identity | `0xED6d1aF5556a4407B09776cd64d28098880c7EAa` |
| ERC-8004 Reputation | `0x78Cb2B126BCC07ca2843CBd290eBb813c8Fb718D` |
| ERC-8004 Validation | `0xb66a65441C3e885c5097380605e4333e5278698f` |
| PolarisAccountFactory | `0x9BD12B20bFAf45d18b724A8ECfbfEd942c0b01f2` |

## A dedicated verdict signer

The deployment made one key owner, treasury and verdict signer at once, and the signing runtime is always online. VerifierBridge and the three native extensions now trust `0x6D2725C5`, funded for gas and able to do nothing but sign verdicts. Ownership and treasury stay with the deployer, so a runtime compromise cannot re-point the contracts or move funds. Rotating before any traffic exists is the cheap moment; on testnet the same rotation caused an outage because the runtime was already serving.

## Two script fixes this deployment paid to learn

**`deploy-erc8004.cjs` is now resumable.** It deployed the bootstrap and all three implementations unconditionally, so a first attempt that died before writing any artifact stranded three contracts and 0.124 BOT with nothing recording their addresses. Recovering them from `CREATE(deployer, nonce)` and diffing against the compiled artifacts showed the only differences were two or three exactly-20-byte runs, each containing the contract's own address: `UUPSUpgradeable.__self`, an immutable baked in per deployment. Same code, own address, which is what made reuse safe rather than hopeful.

**`rotate-bot-signer.cjs` was hardcoded to testnet's artifact** and would have rotated signers on addresses that do not exist on mainnet, reporting success for every contract it skipped.

## Gating

`deployed` flips to true only with both halves in place: contracts *and* a runtime serving `/api/index`. It controls whether the app offers the network, and a network in the selector whose market page cannot load is worse than one not offered.

Testnet was verified first, as asked: agent registration plus ERC-8004 mint from a fresh wallet (#8), and all three native-value flows sent for real, including a dispute the AI jury read and rejected on chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)