### PR TITLE
Complete the Vercel env var set, and stop local .env leaking into builds

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,31 @@
+# What must never reach a Vercel build.
+#
+# `vercel deploy` from a workstation uploads the working tree, and it does NOT honour
+# .gitignore. A local `.env` therefore gets uploaded and Vite inlines every VITE_* key in
+# it into the public bundle, silently overriding what is configured in the dashboard. That
+# happened: a CLI deploy shipped a local `VITE_API_URL`, which is a single global API base
+# that beats every network's own. It was harmless only because each network also has an
+# explicit VITE_API_URL_<NETWORK>, which takes precedence; without one, BOT Chain requests
+# would have gone to the Arc runtime and been refused with a 409.
+#
+# Vercel's own environment variables are the only source of build config, so local env
+# files have no business here.
+.env
+.env.*
+!.env.example
+
+# Local runtime state. The SQLite index is written live, and an in-flight write inside an
+# upload is what truncated a Railway snapshot once already.
+.state/
+*.db
+*.db-shm
+*.db-wal
+server/*.json
+!server/package.json
+!server/package-lock.json
+
+# Never needed to build the frontend.
+contracts/artifacts/
+contracts/cache/
+node_modules
+dist


### PR DESCRIPTION
## Six variables were never set

`VITE_BOT_TESTNET_RPC` / `_EXPLORER` / `_CHAIN_ID` and the three mainnet equivalents. The app worked because `chains.ts` falls back to the same values, but a deployment that depends on invisible fallbacks can't be audited from the dashboard. All 18 required vars are now set for Production and Preview, and verified **inlined in the served bundle** rather than trusted from the dashboard:

| Var | Value |
|---|---|
| `VITE_BOT_TESTNET_RPC` | `https://rpc.bohr.life` |
| `VITE_BOT_TESTNET_EXPLORER` | `https://scan.bohr.life` |
| `VITE_BOT_TESTNET_CHAIN_ID` | `968` |
| `VITE_BOT_MAINNET_RPC` | `https://rpc.botchain.ai` |
| `VITE_BOT_MAINNET_EXPLORER` | `https://scan.botchain.ai` |
| `VITE_BOT_MAINNET_CHAIN_ID` | `677` |

`VITE_API_URL` stays deliberately **unset** — it is a single global API base that beats every network's own default, so setting it sends BOT requests to the Arc runtime, which refuses them with a 409.

## Which is what a CLI deploy then did

`vercel deploy` uploads the working tree and does **not** honour `.gitignore`, so a local `.env` was uploaded and Vite inlined its `VITE_API_URL` into the public bundle. No outage resulted, but only because every network now has an explicit `VITE_API_URL_<NETWORK>` and `apiBase` gives those precedence. Depending on that is not a plan.

`.vercelignore` now keeps local env files out of a build entirely, plus live SQLite state (an in-flight write inside an upload has already truncated one snapshot) and build artifacts that cannot contribute to a frontend build.

Worth recording what was **not** exposed: the leaked file held only `VITE_*` keys, which are public by construction since they ship to every browser, and no non-VITE secret at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)