### PR TITLE
Guarantee every task terminates, and make the auction a real auction

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -148,3 +148,9 @@ INTERNAL_API_SECRET=
 # between them and taken three below the bid floor, for failures caused by the missing reaper
 # itself. Defaults to process start. Set to 0 to enforce the backlog too, deliberately.
 # REAPER_ENFORCE_FROM_MS=0
+#
+# How long an auction stays open before it is awarded on score. The raw-key swarm used to
+# award the instant it bid, which made the market first-poll-wins: one bid per task, and
+# BidEngine's price/reputation/speed scoring never saw a competitor. The UI has always
+# advertised 20 minutes. Clamped to the time left before the deadline.
+# BID_WINDOW_MS=1200000

--- a/server/.env.example
+++ b/server/.env.example
@@ -126,3 +126,18 @@ INTERNAL_API_SECRET=
 # checkpoint that never advances, which is how a production index ends up empty).
 # INDEX_CHUNK_DELAY_MS=120                       # wait between getLogs chunks
 # INDEX_RATE_LIMIT_BACKOFF_MS=1000,2500,6000,12000   # per successive refusal
+
+# ── Never letting a task get stuck ───────────────────────────────────────────
+# A task that cannot make progress must still reach a terminal state. Two guards:
+#
+# The agent's retry budget for producing + submitting a deliverable. Without a ceiling a
+# permanently-failing task was retried every tick forever, paying for a model call each pass
+# while pinned in ASSIGNED. Spent budget hands the task to the reaper.
+# FULFIL_MAX_ATTEMPTS=3
+#
+# The deadline reaper. `slashOnTimeout` is permissionless, so the verdict signer can call it:
+# it refunds the requester and slashes the agent that missed the deadline. The grace period
+# exists because block timestamps and our clock are different clocks, and the contract
+# requires block.timestamp > deadline strictly.
+# REAPER_POLL_MS=120000
+# REAPER_GRACE_MS=60000

--- a/server/.env.example
+++ b/server/.env.example
@@ -141,3 +141,10 @@ INTERNAL_API_SECRET=
 # requires block.timestamp > deadline strictly.
 # REAPER_POLL_MS=120000
 # REAPER_GRACE_MS=60000
+#
+# Deadlines before this instant are NOT enforced. Enforcement was missing for the whole life
+# of the deployment, so switching it on finds a backlog, and `slashOnTimeout` refunds and
+# slashes atomically: clearing 114 stale tasks on Arc would have slashed four agents 114 times
+# between them and taken three below the bid floor, for failures caused by the missing reaper
+# itself. Defaults to process start. Set to 0 to enforce the backlog too, deliberately.
+# REAPER_ENFORCE_FROM_MS=0

--- a/server/agent-circle.js
+++ b/server/agent-circle.js
@@ -3,6 +3,11 @@ import "dotenv/config";
 
 import { ADDR, ABI, provider, readTaskMeta, USDC_DECIMALS, requireAddresses, queryLogsChunked } from "./chain.js";
 import { produceWork } from "./score.js";
+import { clearFailures, exhausted, FULFIL_MAX_ATTEMPTS, recordFailure } from "./fulfilAttempts.js";
+import { DEFAULT_NETWORK, getNetwork } from "./networks.js";
+
+/** This swarm is Arc-only: Circle MPC wallets have no BOT Chain presence. */
+const ARC_CHAIN_ID = getNetwork(DEFAULT_NETWORK).chainId;
 import { listAgentWallets, fundWallet, execute, isLoggedIn, CIRCLE_CHAIN } from "./circle-wallet.js";
 
 /**
@@ -242,10 +247,22 @@ class CircleAgent {
         this.log(`rejected "${meta.title}" ${result.score}/100${result.reopened ? " → returned to market" : ""}: ${String(result.feedback || "").slice(0, 90)}`);
       }
       this.inFlight -= 1;
+      clearFailures(ARC_CHAIN_ID, taskId);
     } catch (e) {
-      this.handled.delete(taskId);
       if (this.inFlight > 0) this.inFlight -= 1;
-      this.log("fulfil error:", e.message);
+      // Same bounded retry as the raw-key swarm (server/agent.js). Clearing `handled`
+      // unconditionally meant a task that could never succeed was re-attempted every tick,
+      // paying for a model call each pass while pinned in ASSIGNED.
+      const n = recordFailure(ARC_CHAIN_ID, taskId, e.message);
+      if (n >= FULFIL_MAX_ATTEMPTS) {
+        this.log(
+          `giving up on ${String(taskId).slice(0, 10)} after ${n} attempts: ${e.message}. ` +
+            `Leaving it for the deadline reaper.`,
+        );
+      } else {
+        this.handled.delete(taskId);
+        this.log(`fulfil error (attempt ${n}/${FULFIL_MAX_ATTEMPTS}):`, e.message);
+      }
     }
   }
 

--- a/server/agent.js
+++ b/server/agent.js
@@ -46,6 +46,17 @@ const POLL_MS = Number(process.env.SWARM_POLL_MS || 12000);
  *  pay for the bid and submission that follow. Only meaningful where the stake and
  *  the gas are the same coin (BOT Chain). */
 const GAS_RESERVE = ethers.parseEther(process.env.SWARM_GAS_RESERVE || "0.05");
+/**
+ * How long an auction stays open before it is awarded.
+ *
+ * This swarm used to award the instant it bid, which made the market first-poll-wins: the
+ * first agent to notice a task bid and closed the auction in the same breath, every other
+ * agent hit the `auctionClosed` guard, and BidEngine's scoring (price 40% / reputation 40%
+ * / speed 20%) never saw a second bid to compare. The UI has always advertised a 20-minute
+ * window and `lib/utils.ts` even says it "mirrors the swarm's BID_WINDOW_MS" — a constant
+ * that existed in the Circle swarm and not here, which is the mode BOT Chain runs.
+ */
+const BID_WINDOW_MS = Number(process.env.BID_WINDOW_MS || 20 * 60 * 1000);
 
 /** `botchain-testnet` → `BOTCHAIN_TESTNET` */
 const envKey = (id) => id.replace(/-/g, "_").toUpperCase();
@@ -345,11 +356,11 @@ class Agent {
     try {
       await this.send(this.bid, "placeBid", [taskId, this.units(bidAmount), etaSeconds], { identityCall: true });
       this.log(`bid ${bidAmount} ${this.ctx.asset.symbol} on "${meta.title}" (#${taskId.slice(2, 10)})`);
-      // Close the auction so assignment happens (best-score winner).
-      // Anyone may close the auction, so this one may fall back to the raw key.
-      await this.send(this.bid, "awardBid", [taskId]);
+      // Deliberately does NOT award. Closing the auction here is what made this a race
+      // instead of a market: see BID_WINDOW_MS. The swarm tick closes it once the window has
+      // passed and every agent has had its chance to bid.
     } catch (e) {
-      this.log("bid/award skipped:", e.shortMessage || e.message);
+      this.log("bid skipped:", e.shortMessage || e.message);
     }
   }
 
@@ -531,9 +542,38 @@ export async function startSwarm(networkId = DEFAULT_NETWORK) {
         if (t.deadline * 1000n < BigInt(Date.now())) continue; // expired
         const meta = await ctx.readTaskMeta(taskId);
         if (!meta) continue;
-        for (const a of agents) {
-          // Never let an agent commit to work it can't pay the gas to submit.
-          if (a.wants(meta) && (await a.hasGas())) await a.bidOn(taskId, meta);
+
+        // The auction's own clock, from on-chain data so every agent and every restart
+        // agrees on it: 20 minutes from creation, clamped to whatever is left before the
+        // deadline (a task due sooner than the window cannot wait the full window).
+        const createdAtMs = Number(t.createdAt) * 1000;
+        const deadlineMs = Number(t.deadline) * 1000;
+        const windowMs = Math.min(BID_WINDOW_MS, Math.max(0, deadlineMs - createdAtMs));
+        const windowClosed = Date.now() >= createdAtMs + windowMs;
+
+        if (!windowClosed) {
+          for (const a of agents) {
+            // Never let an agent commit to work it can't pay the gas to submit.
+            if (a.wants(meta) && (await a.hasGas())) await a.bidOn(taskId, meta);
+          }
+          continue;
+        }
+
+        // Window over: close it and let BidEngine pick on score. Idempotent — `awardBid`
+        // guards on `auctionClosed`, so whoever gets there first just finalises the winner.
+        // Done here rather than on a timer because a restart forgets a timer, and a task
+        // left OPEN with bids and nothing to award it is one more way to get stuck.
+        // Any agent may close an auction; pick one that can pay the gas.
+        let closer = null;
+        for (const a of agents) if (await a.hasGas()) { closer = a; break; }
+        if (!closer) continue;
+        try {
+          await closer.send(closer.bid, "awardBid", [taskId]);
+          closer.log(`bidding closed for "${meta.title}" — best bid awarded`);
+        } catch (e) {
+          const msg = e.shortMessage || e.message || "";
+          // "No bids" is normal: nobody wanted it, and it stays OPEN until its deadline.
+          if (!/Auction closed|No bids/i.test(msg)) closer.log("award skipped:", msg);
         }
       }
       for (const a of agents) if (await a.hasGas()) await a.fulfilWins();

--- a/server/agent.js
+++ b/server/agent.js
@@ -16,6 +16,7 @@ import "dotenv/config";
 import { getChainCtx } from "./chain.js";
 import { DEFAULT_NETWORK, getNetwork, isDeployed } from "./networks.js";
 import { produceWork } from "./score.js";
+import { clearFailures, exhausted, FULFIL_MAX_ATTEMPTS, recordFailure } from "./fulfilAttempts.js";
 import { payForService } from "./x402.js";
 
 /**
@@ -363,9 +364,20 @@ class Agent {
     for (const lg of logs) {
       const taskId = lg.args.taskId;
       if (this.handled.has(taskId)) continue;
+      // Durable, so a restart does not reset the budget and resume paying for a task that
+      // has already failed its limit.
+      if (exhausted(this.ctx.chainId, taskId)) {
+        this.handled.add(taskId);
+        continue;
+      }
       this.handled.add(taskId);
+      // Declared outside the try because the catch reports on it. It was a `const` inside
+      // the try, so the "already in progress" branch referenced an out-of-scope binding and
+      // threw a ReferenceError instead of logging: the one branch meant to avoid a pointless
+      // retry was the one that could not run.
+      let meta = null;
       try {
-        const meta = await this.ctx.readTaskMeta(taskId);
+        meta = await this.ctx.readTaskMeta(taskId);
         if (!meta) continue;
         // Optional: pay a sub-cent x402 nanopayment for an oracle quote first.
         // Only on networks with a Circle Gateway facilitator (Arc) — BOT Chain has
@@ -419,16 +431,30 @@ class Agent {
         } else {
           this.log(`settled "${meta.title}" → ${verdict.score}/100 (${verdict.passed ? "PASS" : "FAIL"})`);
         }
+        // Got all the way through, so the task owes nothing to the retry budget.
+        clearFailures(this.ctx.chainId, taskId);
       } catch (e) {
         const msg = e.message || "";
         // "already in progress" is the backend deduplicating a concurrent verify, not
         // a failure. Retrying it re-runs the LLM for nothing, so keep the task
         // handled and let the next tick see the settled state.
         if (/already in progress/i.test(msg)) {
-          this.log(`verification already running for "${meta.title}", waiting`);
+          this.log(`verification already running for "${meta?.title ?? taskId.slice(0, 10)}", waiting`);
+          continue;
+        }
+        // A bounded retry, not an unbounded one. This used to clear `handled`
+        // unconditionally, so a task that could never succeed was retried every tick and
+        // paid for a fresh model call each time while staying pinned in ASSIGNED.
+        const n = recordFailure(this.ctx.chainId, taskId, msg);
+        if (n >= FULFIL_MAX_ATTEMPTS) {
+          this.log(
+            `giving up on ${taskId.slice(0, 10)} after ${n} attempts: ${msg}. ` +
+              `Leaving it for the deadline reaper, which refunds the requester and slashes this agent.`,
+          );
+          // Stays in `handled`, so this process stops spending on it.
         } else {
-          this.handled.delete(taskId); // allow retry next loop
-          this.log("fulfil error:", msg);
+          this.handled.delete(taskId); // retry next loop, within budget
+          this.log(`fulfil error (attempt ${n}/${FULFIL_MAX_ATTEMPTS}):`, msg);
         }
       }
     }

--- a/server/chain.js
+++ b/server/chain.js
@@ -67,6 +67,12 @@ export const ABI = {
   taskRegistry: [
     "function tasks(bytes32) view returns (bytes32 taskId, address requester, uint256 budgetUsdc, uint256 deadline, uint256 minReputation, address assignedAgent, uint8 status, uint256 createdAt, uint256 winningBid)",
     "function reopenTask(bytes32 taskId)",
+    // Permissionless deadline enforcement: refunds the requester and slashes the agent on an
+    // assigned task that blew its deadline. It was missing from this ABI, so the runtime had
+    // no way to call the one escape hatch the contracts provide, and a stalled task stayed
+    // ASSIGNED for good with the budget locked in escrow.
+    "function slashOnTimeout(bytes32 taskId)",
+    "event TaskTimedOut(bytes32 indexed taskId, address indexed agent)",
     "event TaskSubmitted(bytes32 indexed taskId, address indexed requester, uint256 budgetUsdc, uint256 deadline, uint256 minReputation, string title, string description, string rubric, string taskType)",
     "event TaskAssigned(bytes32 indexed taskId, address indexed agent, uint256 bidAmount)",
     "event TaskReopened(bytes32 indexed taskId)",

--- a/server/fulfilAttempts.js
+++ b/server/fulfilAttempts.js
@@ -1,0 +1,110 @@
+/**
+ * How many times an agent has tried and failed to fulfil a task.
+ *
+ * WHY THIS EXISTS. `fulfilWins` used to clear a failed task from its in-memory `handled`
+ * set, which meant "retry on the next tick" with no ceiling. When the failure was permanent
+ * for that task, the agent retried every ~20s indefinitely and paid for a model call each
+ * time. Production showed it: one task looping while the model kept returning nothing, the
+ * task pinned in ASSIGNED, and the requester's escrow locked behind it.
+ *
+ * A retry budget makes the failure terminal from the agent's side. Once it is spent the agent
+ * stops spending money on that task and leaves it to the deadline reaper, which is the only
+ * thing that can actually resolve it on chain.
+ *
+ * DURABLE on purpose. `handled` is in-memory, so a restart previously reset every count and
+ * a permanently-failing task began burning credits again. The counts live with the other
+ * off-chain stores, per chain, since a task id is only unique within a chain.
+ */
+import fs from "node:fs";
+import { networkStorePath } from "./store-path.js";
+
+/** Attempts allowed before an agent gives up on a task. */
+export const FULFIL_MAX_ATTEMPTS = Number(process.env.FULFIL_MAX_ATTEMPTS || 3);
+
+const cache = new Map(); // chainId -> { [taskId]: { n, lastError, lastAtMs } }
+
+function file(chainId) {
+  return networkStorePath(`FULFIL_ATTEMPTS_STORE_${chainId}`, "fulfil-attempts.json", { chainId });
+}
+
+function load(chainId) {
+  let m = cache.get(chainId);
+  if (!m) {
+    try {
+      m = JSON.parse(fs.readFileSync(file(chainId), "utf8"));
+    } catch {
+      m = {};
+    }
+    cache.set(chainId, m);
+  }
+  return m;
+}
+
+/**
+ * Merges over what is on disk rather than replacing it. Several agents share one process and
+ * one file, so a plain read-modify-write would let the last writer erase the others' counts,
+ * which is the same lost-update bug the mintability cache had.
+ */
+function persist(chainId, map) {
+  try {
+    let onDisk = {};
+    try {
+      onDisk = JSON.parse(fs.readFileSync(file(chainId), "utf8"));
+    } catch {
+      /* first write */
+    }
+    const merged = { ...onDisk, ...map };
+    cache.set(chainId, merged);
+    fs.writeFileSync(file(chainId), JSON.stringify(merged));
+  } catch {
+    /* best effort: the in-memory count still bounds this process */
+  }
+}
+
+const key = (taskId) => String(taskId).toLowerCase();
+
+/** Attempts recorded so far. */
+export function attemptsFor(chainId, taskId) {
+  return load(chainId)[key(taskId)]?.n ?? 0;
+}
+
+/** True once the budget is spent and the agent should stop retrying. */
+export function exhausted(chainId, taskId) {
+  return attemptsFor(chainId, taskId) >= FULFIL_MAX_ATTEMPTS;
+}
+
+/** Record a failed attempt; returns the new count. */
+export function recordFailure(chainId, taskId, error) {
+  const map = load(chainId);
+  const k = key(taskId);
+  const n = (map[k]?.n ?? 0) + 1;
+  map[k] = { n, lastError: String(error ?? "").slice(0, 300), lastAtMs: Date.now() };
+  persist(chainId, map);
+  return n;
+}
+
+/** Forget a task's failures once it succeeds, so the store does not grow without bound. */
+export function clearFailures(chainId, taskId) {
+  const map = load(chainId);
+  const k = key(taskId);
+  if (!(k in map)) return;
+  delete map[k];
+  try {
+    let onDisk = {};
+    try {
+      onDisk = JSON.parse(fs.readFileSync(file(chainId), "utf8"));
+    } catch {
+      /* nothing to prune */
+    }
+    delete onDisk[k];
+    cache.set(chainId, onDisk);
+    fs.writeFileSync(file(chainId), JSON.stringify(onDisk));
+  } catch {
+    /* best effort */
+  }
+}
+
+/** Test seam. */
+export function resetFulfilAttemptsCache() {
+  cache.clear();
+}

--- a/server/llm.js
+++ b/server/llm.js
@@ -151,7 +151,26 @@ export async function chat(messages, opts = {}) {
 
       const data = JSON.parse(text);
       if (data.error) throw new Error(`LLM error: ${JSON.stringify(data.error).slice(0, 300)}`);
-      return data.choices?.[0]?.message?.content ?? "";
+
+      // An empty completion is a FAILURE, not a value.
+      //
+      // This used to `?? ""`, and that empty string became the agent's deliverable. The
+      // deliverable endpoint then correctly refused it with 400 "taskId and deliverable
+      // required", the agent treated the 400 as retryable, and the task retried every ~20s
+      // forever: a model call paid for on each pass, and a task that could never leave
+      // ASSIGNED. A provider that returns no content (a refusal, a truncation, a filtered
+      // response) has failed, and the only safe thing to do with a failure is surface it.
+      //
+      // Marked retryable because the usual causes are transient, so the retry ladder above
+      // gets a chance before the caller ever sees it.
+      const content = data.choices?.[0]?.message?.content;
+      if (typeof content !== "string" || content.trim() === "") {
+        const reason = data.choices?.[0]?.finish_reason ?? "none";
+        const err = new Error(`LLM returned an empty completion (model=${model}, finish_reason=${reason})`);
+        err.retryable = true;
+        throw err;
+      }
+      return content;
     } catch (e) {
       lastErr = e;
       const retryable = e.retryable || e.name === "TimeoutError" || e.name === "AbortError";

--- a/server/reaper.js
+++ b/server/reaper.js
@@ -1,0 +1,131 @@
+/**
+ * The terminal-state guarantee: no task may sit in a working state forever.
+ *
+ * WHY THIS EXISTS. `NativeTaskRegistry.slashOnTimeout` (and Arc's equivalent) is deliberately
+ * permissionless — "anyone can enforce a missed deadline" — and refunds the requester while
+ * slashing the agent that missed it. Nothing called it. The contracts shipped the escape
+ * hatch and the runtime never used it, so an ASSIGNED task whose agent never delivered stayed
+ * ASSIGNED past its deadline permanently, with the requester's budget locked in escrow. That
+ * is what "stuck in progress" actually was.
+ *
+ * WHAT IT DOES NOT DO. An OPEN task past its deadline is not resolvable here: only the
+ * requester may `cancelTask`, and adding an authorised expiry would need a contract change
+ * that Arc's live deployment cannot take. Those are surfaced in the UI as expired with the
+ * requester's own refund action instead of being quietly left to look healthy.
+ *
+ * COST DISCIPLINE. Reads come from the checkpointed index, never a fresh log scan: this is
+ * the same rate-limited RPC whose throttling once left production serving 4 tasks out of 270.
+ * A tick with nothing to do costs one cached index read and no chain calls at all.
+ */
+import { ethers } from "ethers";
+import { getChainCtx } from "./chain.js";
+import { getNetwork, isDeployed, signerKeyFor } from "./networks.js";
+import { getIndex } from "./indexer.js";
+
+/** How often to look. Deadlines are hours apart, so this does not need to be eager. */
+const POLL_MS = Number(process.env.REAPER_POLL_MS || 120000);
+
+/**
+ * Grace period past the deadline before enforcing.
+ *
+ * Block timestamps and the indexer's clock are not the same clock, and `slashOnTimeout`
+ * requires `block.timestamp > deadline` strictly. Enforcing the instant our own clock passes
+ * the deadline would just produce "Before deadline" reverts, so wait out the skew.
+ */
+const GRACE_MS = Number(process.env.REAPER_GRACE_MS || 60000);
+
+/** On-chain Status enum: OPEN, ASSIGNED, IN_PROGRESS, COMPLETED, SETTLED, CANCELLED. */
+const STATUS = { OPEN: 0, ASSIGNED: 1, IN_PROGRESS: 2, COMPLETED: 3, SETTLED: 4, CANCELLED: 5 };
+/** The states a deadline can be enforced from, matching the contract's own require(). */
+const ENFORCEABLE = new Set([STATUS.ASSIGNED, STATUS.IN_PROGRESS]);
+
+/** Reverts that mean "nothing to do", not "something went wrong". */
+const BENIGN = /Before deadline|Not in progress/i;
+
+/**
+ * Tasks the index believes are working and overdue.
+ *
+ * Deliberately derived from the index rather than the chain: the chain is consulted once per
+ * candidate, immediately before acting, which is where the authoritative check belongs.
+ */
+export function overdueCandidates(index, { now = Date.now(), graceMs = GRACE_MS } = {}) {
+  const cutoff = now - graceMs;
+  return (index?.tasks ?? []).filter(
+    (t) => (t.status === "ASSIGNED" || t.status === "IN_PROGRESS") && t.deadlineMs && t.deadlineMs < cutoff,
+  );
+}
+
+/**
+ * Enforce one task's deadline. Returns what happened, so a caller (and a test) can tell a
+ * no-op from a real enforcement without reading logs.
+ */
+export async function enforceDeadline(ctx, registry, task) {
+  // Re-read on chain before sending. The index can be a couple of minutes stale, and paying
+  // gas to be told the task already settled is avoidable.
+  const onChain = await registry.tasks(task.taskId);
+  const status = Number(onChain.status);
+  if (!ENFORCEABLE.has(status)) return { taskId: task.taskId, action: "skipped", reason: `status ${status}` };
+
+  const deadlineMs = Number(onChain.deadline) * 1000;
+  if (deadlineMs >= Date.now()) return { taskId: task.taskId, action: "skipped", reason: "before deadline" };
+
+  try {
+    const tx = await registry.slashOnTimeout(task.taskId);
+    await tx.wait();
+    return { taskId: task.taskId, action: "timed-out", txHash: tx.hash };
+  } catch (e) {
+    const msg = e.shortMessage || e.message || "";
+    // Another caller (anyone may) got there first, or the clocks disagreed. Not an error.
+    if (BENIGN.test(msg)) return { taskId: task.taskId, action: "skipped", reason: msg };
+    return { taskId: task.taskId, action: "failed", reason: msg };
+  }
+}
+
+/** One pass. Exported so a test can drive it without a timer. */
+export async function reapOnce(networkId) {
+  const key = signerKeyFor(networkId);
+  if (!key) return { network: networkId, skipped: "no signer key configured" };
+
+  const ctx = getChainCtx(networkId);
+  if (!ctx.ADDR.taskRegistry) return { network: networkId, skipped: "no task registry" };
+
+  const index = await getIndex(networkId);
+  const candidates = overdueCandidates(index);
+  if (candidates.length === 0) return { network: networkId, checked: 0, results: [] };
+
+  // `slashOnTimeout` is permissionless, so the verdict signer is enough. No owner key is
+  // involved, which is the point of having split them.
+  const wallet = new ethers.Wallet(key, ctx.provider);
+  const registry = new ethers.Contract(ctx.ADDR.taskRegistry, ctx.ABI.taskRegistry, wallet);
+
+  const results = [];
+  for (const task of candidates) {
+    results.push(await enforceDeadline(ctx, registry, task));
+  }
+  return { network: networkId, checked: candidates.length, results };
+}
+
+/** Start the per-network ticker, in the shape the other services use. */
+export function startReaper(networkId) {
+  if (!isDeployed(networkId)) return;
+  const label = getNetwork(networkId).label;
+
+  const tick = async () => {
+    try {
+      const out = await reapOnce(networkId);
+      for (const r of out.results ?? []) {
+        if (r.action === "timed-out") {
+          console.log(`[reaper:${networkId}] ${r.taskId.slice(0, 10)} passed its deadline → refunded requester, slashed agent (${r.txHash})`);
+        } else if (r.action === "failed") {
+          console.error(`[reaper:${networkId}] ${r.taskId.slice(0, 10)} enforcement failed: ${r.reason}`);
+        }
+      }
+    } catch (e) {
+      console.error(`[reaper:${networkId}] tick error:`, e.message);
+    }
+  };
+
+  tick();
+  setInterval(tick, POLL_MS).unref();
+  console.log(`[reaper:${networkId}] deadline enforcement on · every ${POLL_MS / 1000}s · ${label}`);
+}

--- a/server/reaper.js
+++ b/server/reaper.js
@@ -43,16 +43,58 @@ const ENFORCEABLE = new Set([STATUS.ASSIGNED, STATUS.IN_PROGRESS]);
 const BENIGN = /Before deadline|Not in progress/i;
 
 /**
+ * Deadlines before this are not enforced.
+ *
+ * WHY A CUTOFF EXISTS AT ALL. Enforcement was missing for the whole life of the deployment, so
+ * switching it on found a backlog: 114 tasks on Arc, some 40 days overdue, holding 218 USDC.
+ * `slashOnTimeout` refunds and slashes atomically, so clearing that backlog would have slashed
+ * four agents 114 times between them and taken three of them to reputation 0 and roughly 1-3
+ * USDC of stake, below the minimum and below BidEngine's bid floor of 70. They would never bid
+ * again.
+ *
+ * Those tasks failed because nothing enforced deadlines, which is this bug, not because the
+ * agents misbehaved. Punishing them retroactively for our own missing component would be
+ * both unjust and self-defeating. So enforcement applies to deadlines that pass from the
+ * moment it ships, and the backlog is left alone: still visible, and now labelled Overdue in
+ * the UI rather than dressed up as "In progress".
+ *
+ * Set REAPER_ENFORCE_FROM_MS=0 to enforce the backlog too, deliberately and with the
+ * consequences above in view.
+ */
+const ENFORCE_FROM_MS = (() => {
+  const raw = process.env.REAPER_ENFORCE_FROM_MS;
+  if (raw !== undefined && raw !== "") {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  // Default: this process's start. A restart moves it forward, which is the safe direction:
+  // it can only ever decline to punish, never punish more.
+  return Date.now();
+})();
+
+/**
  * Tasks the index believes are working and overdue.
  *
  * Deliberately derived from the index rather than the chain: the chain is consulted once per
  * candidate, immediately before acting, which is where the authoritative check belongs.
  */
-export function overdueCandidates(index, { now = Date.now(), graceMs = GRACE_MS } = {}) {
+export function overdueCandidates(
+  index,
+  { now = Date.now(), graceMs = GRACE_MS, enforceFromMs = ENFORCE_FROM_MS } = {},
+) {
   const cutoff = now - graceMs;
   return (index?.tasks ?? []).filter(
-    (t) => (t.status === "ASSIGNED" || t.status === "IN_PROGRESS") && t.deadlineMs && t.deadlineMs < cutoff,
+    (t) =>
+      (t.status === "ASSIGNED" || t.status === "IN_PROGRESS") &&
+      t.deadlineMs &&
+      t.deadlineMs < cutoff &&
+      t.deadlineMs >= enforceFromMs,
   );
+}
+
+/** What the reaper is currently willing to enforce, for logging and tests. */
+export function enforceFromMs() {
+  return ENFORCE_FROM_MS;
 }
 
 /**
@@ -127,5 +169,8 @@ export function startReaper(networkId) {
 
   tick();
   setInterval(tick, POLL_MS).unref();
-  console.log(`[reaper:${networkId}] deadline enforcement on · every ${POLL_MS / 1000}s · ${label}`);
+  console.log(
+    `[reaper:${networkId}] deadline enforcement on · every ${POLL_MS / 1000}s · ${label} · ` +
+      `enforcing deadlines from ${new Date(ENFORCE_FROM_MS).toISOString()} (earlier ones are grandfathered)`,
+  );
 }

--- a/server/runtime.js
+++ b/server/runtime.js
@@ -24,6 +24,7 @@ import { startScheduler } from "./subscriptions.js";
 import { startHostedRuntime } from "./hosted.js";
 import { startRecurringMarket } from "./recurring.js";
 import { startDisputeResolver } from "./disputes.js";
+import { startReaper } from "./reaper.js";
 import { startSwarm } from "./agent.js";
 
 const networks = activeNetworkIds();
@@ -36,6 +37,10 @@ for (const id of networks) {
   startRecurringMarket(id);
   // Dispute auto-resolver: settles any dispute the client didn't finish resolving.
   startDisputeResolver(id);
+  // Deadline enforcement. Every other service here advances work that is going well; this is
+  // the one that guarantees work which is NOT going well still reaches a terminal state
+  // instead of pinning a task in ASSIGNED and the budget in escrow.
+  startReaper(id);
   // Hosted persona agents (Phase B) — runs user-registered personas server-side.
   if (process.env.HOSTED_AGENTS === "1") startHostedRuntime(id);
 }

--- a/server/score.js
+++ b/server/score.js
@@ -190,21 +190,35 @@ export async function produceWork(p, feedback = "") {
   const revision = feedback
     ? `\n\nYOUR PREVIOUS SUBMISSION WAS REJECTED. Reviewer feedback to fix:\n${feedback}\nProduce an improved deliverable that fully addresses this.`
     : "";
-  let out = await chat(
-    [
-      {
-        role: "system",
-        content:
-          `You are an AI worker agent completing a paid task. Produce the deliverable directly — no preamble, no meta-commentary. Satisfy EVERY criterion in the rubric, and match the requested length and format EXACTLY. ${intentNote} ${lengthNote} ${fmtNote}`.trim(),
-      },
-      {
-        role: "user",
-        content: `TASK: ${p.title}\n${p.description}\n\nRUBRIC (you will be scored against this): ${p.rubric}${revision}`,
-      },
-    ],
-    { maxTokens: tokensFor(spec) },
-  );
+  const messages = [
+    {
+      role: "system",
+      content:
+        `You are an AI worker agent completing a paid task. Produce the deliverable directly — no preamble, no meta-commentary. Satisfy EVERY criterion in the rubric, and match the requested length and format EXACTLY. ${intentNote} ${lengthNote} ${fmtNote}`.trim(),
+    },
+    {
+      role: "user",
+      content: `TASK: ${p.title}\n${p.description}\n\nRUBRIC (you will be scored against this): ${p.rubric}${revision}`,
+    },
+  ];
+
+  // One extra attempt of our own on top of the transport-level retries in chat(). A model
+  // that returns nothing is usually transient, and one more try is far cheaper than the
+  // alternative this code used to produce: an empty deliverable that no endpoint would
+  // accept, retried by the agent forever.
+  let out;
+  try {
+    out = await chat(messages, { maxTokens: tokensFor(spec) });
+  } catch (e) {
+    console.warn(`[score] first generation attempt failed, retrying once: ${e.message}`);
+    out = await chat(messages, { maxTokens: tokensFor(spec) });
+  }
   out = stripFences(out, spec.format);
+  // Never hand back a deliverable nothing can accept. `stripFences` can also empty a
+  // response that was nothing but a code fence, so this is checked after it, not before.
+  if (typeof out !== "string" || out.trim() === "") {
+    throw new Error("the model produced no usable deliverable for this task");
+  }
   // A PDF request → render the produced document into a real PDF file (data-URI).
   if (spec.format === "pdf") {
     try {

--- a/server/test/stuckTasks.test.js
+++ b/server/test/stuckTasks.test.js
@@ -1,0 +1,196 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * A task must never be able to get stuck.
+ *
+ * Three defects conspired to pin a task in ASSIGNED forever, and each is pinned here.
+ *
+ * 1. `chat()` ended with `?? ""`, so a model that returned no content produced an empty
+ *    deliverable. The deliverable endpoint refused it with a 400, the agent treated the 400
+ *    as retryable, and it retried every ~20s indefinitely, paying for a model call each pass.
+ * 2. The fulfil path had no retry ceiling at all.
+ * 3. Nothing ever called `slashOnTimeout`, the permissionless escape hatch the contracts
+ *    provide, so a task whose agent never delivered stayed ASSIGNED past its deadline with
+ *    the requester's budget locked in escrow.
+ */
+
+process.env.POLARIS_STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "polaris-stuck-"));
+
+/* ── 1. An empty completion is a failure ──────────────────────────────────────── */
+
+let fetchImpl = null;
+globalThis.fetch = (...a) => fetchImpl(...a);
+
+const okBody = (content) => ({
+  ok: true,
+  status: 200,
+  text: async () => JSON.stringify({ choices: [{ message: { content }, finish_reason: "stop" }] }),
+});
+
+process.env.OPENROUTER_API_KEY = "test-key";
+process.env.LLM_RETRIES = "0";
+const { chat } = await import("../llm.js");
+
+test("an empty completion throws instead of becoming an empty deliverable", async () => {
+  fetchImpl = async () => okBody("");
+  await assert.rejects(() => chat([{ role: "user", content: "hi" }]), /empty completion/i);
+});
+
+test("a whitespace-only completion is also a failure", async () => {
+  fetchImpl = async () => okBody("   \n\t ");
+  await assert.rejects(() => chat([{ role: "user", content: "hi" }]), /empty completion/i);
+});
+
+test("a missing content field is a failure, not undefined", async () => {
+  fetchImpl = async () => ({ ok: true, status: 200, text: async () => JSON.stringify({ choices: [{ message: {} }] }) });
+  await assert.rejects(() => chat([{ role: "user", content: "hi" }]), /empty completion/i);
+});
+
+test("a real completion still comes back untouched", async () => {
+  fetchImpl = async () => okBody("the actual deliverable");
+  assert.equal(await chat([{ role: "user", content: "hi" }]), "the actual deliverable");
+});
+
+/* ── 2. The fulfil retry budget ───────────────────────────────────────────────── */
+
+const { attemptsFor, clearFailures, exhausted, recordFailure, FULFIL_MAX_ATTEMPTS, resetFulfilAttemptsCache } =
+  await import("../fulfilAttempts.js");
+
+test("an agent gives up after the retry budget instead of looping forever", () => {
+  const task = "0xaaa1";
+  assert.equal(exhausted(968, task), false);
+  for (let i = 1; i < FULFIL_MAX_ATTEMPTS; i++) {
+    recordFailure(968, task, "the model produced no usable deliverable");
+    assert.equal(exhausted(968, task), false, `still within budget at ${i}`);
+  }
+  recordFailure(968, task, "again");
+  assert.equal(exhausted(968, task), true, "budget spent, stop paying for this task");
+});
+
+test("the budget survives a restart, so a restart cannot resume the loop", () => {
+  const task = "0xaaa2";
+  for (let i = 0; i < FULFIL_MAX_ATTEMPTS; i++) recordFailure(968, task, "boom");
+  resetFulfilAttemptsCache(); // as if the process restarted
+  assert.equal(exhausted(968, task), true);
+});
+
+test("counts are per chain, because a task id is only unique within one", () => {
+  const task = "0xaaa3";
+  for (let i = 0; i < FULFIL_MAX_ATTEMPTS; i++) recordFailure(968, task, "boom");
+  assert.equal(exhausted(968, task), true);
+  assert.equal(exhausted(5042002, task), false);
+});
+
+test("success clears the record, so the store does not grow without bound", () => {
+  const task = "0xaaa4";
+  recordFailure(968, task, "transient");
+  assert.equal(attemptsFor(968, task), 1);
+  clearFailures(968, task);
+  assert.equal(attemptsFor(968, task), 0);
+});
+
+test("concurrent failures on one chain do not overwrite each other", () => {
+  // Several agents share one process and one file; a read-modify-write would lose entries.
+  const tasks = ["0xbbb1", "0xbbb2", "0xbbb3"];
+  for (const t of tasks) recordFailure(968, t, "boom");
+  resetFulfilAttemptsCache();
+  for (const t of tasks) assert.equal(attemptsFor(968, t), 1, `${t} survived`);
+});
+
+/* ── 3. The reaper ────────────────────────────────────────────────────────────── */
+
+const HOUR = 3600_000;
+mock.module("../indexer.js", { namedExports: { getIndex: async () => ({ tasks: [] }) } });
+const { overdueCandidates, enforceDeadline } = await import("../reaper.js");
+
+test("only non-terminal, past-deadline tasks are candidates", () => {
+  const now = Date.now();
+  const tasks = [
+    { taskId: "0x1", status: "ASSIGNED", deadlineMs: now - 2 * HOUR },
+    { taskId: "0x2", status: "IN_PROGRESS", deadlineMs: now - 2 * HOUR },
+    { taskId: "0x3", status: "ASSIGNED", deadlineMs: now + 2 * HOUR }, // still has time
+    { taskId: "0x4", status: "OPEN", deadlineMs: now - 2 * HOUR }, // requester-only to resolve
+    { taskId: "0x5", status: "SETTLED", deadlineMs: now - 9 * HOUR }, // terminal
+    { taskId: "0x6", status: "CANCELLED", deadlineMs: now - 9 * HOUR }, // terminal
+  ];
+  assert.deepEqual(overdueCandidates({ tasks }, { now }).map((t) => t.taskId), ["0x1", "0x2"]);
+});
+
+test("the grace period keeps us from fighting block-timestamp skew", () => {
+  const now = Date.now();
+  // Just barely past our clock: `slashOnTimeout` requires block.timestamp > deadline
+  // strictly, so acting immediately would only earn a "Before deadline" revert.
+  const tasks = [{ taskId: "0x1", status: "ASSIGNED", deadlineMs: now - 1000 }];
+  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 60000 }).length, 0);
+  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 0 }).length, 1);
+});
+
+/** A registry whose task status and revert behaviour the test controls. */
+function registryStub({ status, deadlineSec, revert = null, sent = [] }) {
+  return {
+    sent,
+    tasks: async () => ({ status, deadline: BigInt(deadlineSec) }),
+    slashOnTimeout: async (taskId) => {
+      if (revert) { const e = new Error(revert); throw e; }
+      sent.push(taskId);
+      return { hash: "0xtx", wait: async () => ({}) };
+    },
+  };
+}
+
+const past = Math.floor((Date.now() - 2 * HOUR) / 1000);
+const future = Math.floor((Date.now() + 2 * HOUR) / 1000);
+
+test("an overdue assigned task is timed out on chain", async () => {
+  const reg = registryStub({ status: 1, deadlineSec: past });
+  const r = await enforceDeadline({}, reg, { taskId: "0x1" });
+  assert.equal(r.action, "timed-out");
+  assert.deepEqual(reg.sent, ["0x1"]);
+});
+
+test("a task that settled since the index was built is left alone", async () => {
+  // The index can be minutes stale; paying gas to be told it already settled is avoidable.
+  const reg = registryStub({ status: 4, deadlineSec: past });
+  const r = await enforceDeadline({}, reg, { taskId: "0x1" });
+  assert.equal(r.action, "skipped");
+  assert.deepEqual(reg.sent, []);
+});
+
+test("the on-chain deadline is authoritative over the index's", async () => {
+  const reg = registryStub({ status: 1, deadlineSec: future });
+  const r = await enforceDeadline({}, reg, { taskId: "0x1" });
+  assert.equal(r.action, "skipped");
+  assert.deepEqual(reg.sent, []);
+});
+
+test("a benign revert is a no-op, not an error", async () => {
+  // Enforcement is permissionless, so anyone may have got there first.
+  for (const msg of ["execution reverted: Not in progress", "execution reverted: Before deadline"]) {
+    const r = await enforceDeadline({}, registryStub({ status: 1, deadlineSec: past, revert: msg }), { taskId: "0x1" });
+    assert.equal(r.action, "skipped", msg);
+  }
+});
+
+test("a real failure is reported rather than swallowed", async () => {
+  const r = await enforceDeadline({}, registryStub({ status: 1, deadlineSec: past, revert: "insufficient funds" }), { taskId: "0x1" });
+  assert.equal(r.action, "failed");
+  assert.match(r.reason, /insufficient funds/);
+});
+
+test("enforcement is idempotent across two ticks", async () => {
+  const sent = [];
+  let status = 1;
+  const reg = {
+    sent,
+    tasks: async () => ({ status, deadline: BigInt(past) }),
+    slashOnTimeout: async (taskId) => { sent.push(taskId); status = 5; return { hash: "0xtx", wait: async () => ({}) }; },
+  };
+  assert.equal((await enforceDeadline({}, reg, { taskId: "0x1" })).action, "timed-out");
+  assert.equal((await enforceDeadline({}, reg, { taskId: "0x1" })).action, "skipped");
+  assert.deepEqual(sent, ["0x1"], "sent exactly once");
+});

--- a/server/test/stuckTasks.test.js
+++ b/server/test/stuckTasks.test.js
@@ -108,6 +108,9 @@ const HOUR = 3600_000;
 mock.module("../indexer.js", { namedExports: { getIndex: async () => ({ tasks: [] }) } });
 const { overdueCandidates, enforceDeadline } = await import("../reaper.js");
 
+/** Default the cutoff off, so the existing selection tests read as before. */
+const ANY = { enforceFromMs: 0 };
+
 test("only non-terminal, past-deadline tasks are candidates", () => {
   const now = Date.now();
   const tasks = [
@@ -118,7 +121,7 @@ test("only non-terminal, past-deadline tasks are candidates", () => {
     { taskId: "0x5", status: "SETTLED", deadlineMs: now - 9 * HOUR }, // terminal
     { taskId: "0x6", status: "CANCELLED", deadlineMs: now - 9 * HOUR }, // terminal
   ];
-  assert.deepEqual(overdueCandidates({ tasks }, { now }).map((t) => t.taskId), ["0x1", "0x2"]);
+  assert.deepEqual(overdueCandidates({ tasks }, { now, ...ANY }).map((t) => t.taskId), ["0x1", "0x2"]);
 });
 
 test("the grace period keeps us from fighting block-timestamp skew", () => {
@@ -126,8 +129,8 @@ test("the grace period keeps us from fighting block-timestamp skew", () => {
   // Just barely past our clock: `slashOnTimeout` requires block.timestamp > deadline
   // strictly, so acting immediately would only earn a "Before deadline" revert.
   const tasks = [{ taskId: "0x1", status: "ASSIGNED", deadlineMs: now - 1000 }];
-  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 60000 }).length, 0);
-  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 0 }).length, 1);
+  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 60000, ...ANY }).length, 0);
+  assert.equal(overdueCandidates({ tasks }, { now, graceMs: 0, ...ANY }).length, 1);
 });
 
 /** A registry whose task status and revert behaviour the test controls. */
@@ -193,4 +196,27 @@ test("enforcement is idempotent across two ticks", async () => {
   assert.equal((await enforceDeadline({}, reg, { taskId: "0x1" })).action, "timed-out");
   assert.equal((await enforceDeadline({}, reg, { taskId: "0x1" })).action, "skipped");
   assert.deepEqual(sent, ["0x1"], "sent exactly once");
+});
+
+test("a pre-existing backlog is grandfathered, not retroactively punished", () => {
+  // Enforcement was missing for the deployment's whole life, so switching it on found 114
+  // overdue tasks on Arc. Clearing them would have slashed four agents 114 times between
+  // them and taken three to reputation 0, below the bid floor, for failures caused by the
+  // missing reaper itself. Only deadlines that pass after enforcement starts are eligible.
+  const now = Date.now();
+  const enforceFromMs = now - 1 * HOUR; // reaper started an hour ago
+  const tasks = [
+    { taskId: "0xold", status: "ASSIGNED", deadlineMs: now - 40 * 24 * HOUR }, // 40 days stale
+    { taskId: "0xnew", status: "ASSIGNED", deadlineMs: now - 30 * 60_000 }, // expired since
+  ];
+  assert.deepEqual(
+    overdueCandidates({ tasks }, { now, enforceFromMs }).map((t) => t.taskId),
+    ["0xnew"],
+  );
+});
+
+test("the backlog can be enforced deliberately, with the cutoff turned off", () => {
+  const now = Date.now();
+  const tasks = [{ taskId: "0xold", status: "ASSIGNED", deadlineMs: now - 40 * 24 * HOUR }];
+  assert.equal(overdueCandidates({ tasks }, { now, enforceFromMs: 0 }).length, 1);
 });

--- a/server/test/stuckTasks.test.js
+++ b/server/test/stuckTasks.test.js
@@ -220,3 +220,55 @@ test("the backlog can be enforced deliberately, with the cutoff turned off", () 
   const tasks = [{ taskId: "0xold", status: "ASSIGNED", deadlineMs: now - 40 * 24 * HOUR }];
   assert.equal(overdueCandidates({ tasks }, { now, enforceFromMs: 0 }).length, 1);
 });
+
+/* ── 4. The auction must actually be an auction ───────────────────────────────── */
+
+/**
+ * Bidding used to close the auction in the same breath as placing the bid, which made the
+ * market first-poll-wins: the first agent to notice a task bid AND awarded it, every other
+ * agent hit BidEngine's `auctionClosed` guard, and the on-chain scoring (price 40% /
+ * reputation 40% / speed 20%) never had a second bid to compare. One bid per task, always.
+ *
+ * The window is now derived from on-chain data so every agent and every restart agrees, and
+ * closing happens in the tick rather than on a `setTimeout` a restart would forget.
+ */
+const BID_WINDOW_MS = 20 * 60 * 1000;
+
+/** The rule the swarm applies, kept in one place so the test pins the policy not the code. */
+function auctionState({ createdAtMs, deadlineMs, now, windowMs = BID_WINDOW_MS }) {
+  const w = Math.min(windowMs, Math.max(0, deadlineMs - createdAtMs));
+  return now >= createdAtMs + w ? "award" : "bid";
+}
+
+test("an auction stays open for the whole bid window, so every agent can bid", () => {
+  const created = Date.now();
+  const deadline = created + 6 * HOUR;
+  // Seconds in: still collecting bids, which is what the old code got wrong.
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + 5000 }), "bid");
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + 19 * 60_000 }), "bid");
+});
+
+test("once the window passes, the auction is awarded on score", () => {
+  const created = Date.now();
+  const deadline = created + 6 * HOUR;
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + BID_WINDOW_MS }), "award");
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + BID_WINDOW_MS + 1 }), "award");
+});
+
+test("a task due sooner than the window is awarded at its deadline, not after it", () => {
+  // Clamping matters: a 5-minute task must not wait 20 minutes for its auction, or it would
+  // expire unawarded and become exactly the stuck state the reaper has to clean up.
+  const created = Date.now();
+  const deadline = created + 5 * 60_000;
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + 60_000 }), "bid");
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: created + 5 * 60_000 }), "award");
+});
+
+test("the window is computed from creation, so a restart reaches the same verdict", () => {
+  // The Circle swarm schedules the close with setTimeout, which a restart forgets, leaving a
+  // task OPEN with bids and nothing to award it. Deriving it from on-chain createdAt/deadline
+  // means any process, at any time, computes the same answer.
+  const created = Date.now() - 25 * 60_000; // created 25 minutes ago, window long past
+  const deadline = created + 6 * HOUR;
+  assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: Date.now() }), "award");
+});

--- a/src/components/ui/cards.tsx
+++ b/src/components/ui/cards.tsx
@@ -10,7 +10,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { ArrowUpRight, Repeat } from "lucide-react";
 import type { ActivityEvent, Agent, Task } from "../../lib/types";
-import { bidWindow, cn, deadlineLabel, fmtDate, shortAddr, timeAgo } from "../../lib/utils";
+import { bidWindow, cn, deadlineLabel, fmtDate, isOverdue, shortAddr, timeAgo } from "../../lib/utils";
 import { StatusBadge, USDCAmount } from "./primitives";
 import { useAsset } from "../../hooks/useAsset";
 
@@ -108,7 +108,7 @@ export function TaskItem({ task, first }: { task: Task; first?: boolean }) {
       </div>
       <USDCAmount amount={task.budgetUsdc} size="sm" className="shrink-0 text-foreground" />
       <div className="shrink-0 hidden xs:flex justify-end">
-        <StatusBadge status={task.status} />
+        <StatusBadge status={task.status} overdue={isOverdue(task)} />
       </div>
       <ArrowUpRight className="hidden sm:block h-3.5 w-3.5 shrink-0 text-muted-foreground" />
     </Row>
@@ -131,7 +131,7 @@ export function TaskCard({ task }: { task: Task }) {
     >
       <div className="flex items-start justify-between gap-2">
         <p className="line-clamp-2 text-[13px] font-medium text-foreground">{task.title}</p>
-        <StatusBadge status={task.status} />
+        <StatusBadge status={task.status} overdue={isOverdue(task)} />
       </div>
       <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">{task.description}</p>
       <div className="mt-auto flex flex-wrap items-center gap-1.5 border-t border-border pt-2">

--- a/src/components/ui/primitives.tsx
+++ b/src/components/ui/primitives.tsx
@@ -77,13 +77,23 @@ const STATUS_LABEL: Record<string, string> = {
   PENDING: "Under review",
 };
 
-export function StatusBadge({ status }: { status: string }) {
+/**
+ * A task's state, told honestly.
+ *
+ * `overdue` matters: a task past its deadline that has not settled is not "In progress", and
+ * calling it that is what made a stalled task look healthy. An overdue ASSIGNED task reads
+ * **Overdue** (the runtime's reaper refunds the requester and slashes the agent), and an OPEN
+ * task nobody bid on reads **Expired** (only the requester can reclaim it, so the task page
+ * offers them that action). Passed in rather than computed, so reading the clock stays in the
+ * data helpers where `isOverdue` lives.
+ */
+export function StatusBadge({ status, overdue = false }: { status: string; overdue?: boolean }) {
   const key = String(status).toUpperCase();
-  return (
-    <span className={cn("status-badge", STATUS_CLASS[key] ?? "status-submitted")}>
-      {STATUS_LABEL[key] ?? status}
-    </span>
-  );
+
+  const label = overdue && key === "ASSIGNED" ? "Overdue" : overdue && key === "OPEN" ? "Expired" : (STATUS_LABEL[key] ?? status);
+  const cls = overdue && (key === "ASSIGNED" || key === "OPEN") ? "status-disputed" : (STATUS_CLASS[key] ?? "status-submitted");
+
+  return <span className={cn("status-badge", cls)}>{label}</span>;
 }
 
 /** A single figure with its label. Used in tight rows of three or four. */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -120,6 +120,18 @@ export function bidWindow(createdAtMs: number, deadlineMs: number): { closesInMs
  * verifier attestation. The attestation (deliverable hash) is the on-chain proof
  * of completion, so we treat it as done even if the TaskSettled event lagged.
  */
+/**
+ * Past its deadline and still not resolved.
+ *
+ * The distinction the UI got wrong: an ASSIGNED task whose deadline has passed is not "in
+ * progress", it is overdue, and a task that reads as healthy while nothing can advance it is
+ * how a stall goes unnoticed. Terminal states are never overdue, however old they are.
+ */
+export function isOverdue(task: { status: string; deadlineMs?: number; attestation?: { passed: boolean } }): boolean {
+  if (isFinished(task)) return false;
+  return typeof task.deadlineMs === "number" && task.deadlineMs < Date.now();
+}
+
 export function isDone(task: { status: string; attestation?: { passed: boolean } }): boolean {
   return task.status === "SETTLED" || task.attestation?.passed === true;
 }

--- a/src/routes/TaskDetail.tsx
+++ b/src/routes/TaskDetail.tsx
@@ -15,7 +15,7 @@ import { useTx } from "../hooks/useTx";
 import { placeBid, awardBid, cancelTask } from "../lib/tx";
 import { getDeliverable, signDeliverableViewToken } from "../lib/api";
 import { explorerAddr, explorerTx } from "../lib/chain";
-import { shortAddr, deadlineLabel, timeAgo, fmtDate } from "../lib/utils";
+import { shortAddr, deadlineLabel, timeAgo, fmtDate, isOverdue } from "../lib/utils";
 import { useAsset } from "../hooks/useAsset";
 import { useNetwork } from "../context/NetworkProvider";
 
@@ -91,13 +91,15 @@ export default function TaskDetail() {
       (d) => d.status === "OPEN" && (d.requester?.toLowerCase() ?? address.toLowerCase()) === address.toLowerCase(),
     );
   const canDispute = isRequester && task.status === "SETTLED" && !!task.assignedAgent;
+  // Past its deadline and not settled. Drives both the badge and the notice below.
+  const overdue = isOverdue(task);
 
   return (
     <AppShell
       breadcrumb={`#${task.ref}`}
       toolbar={
         <div className="flex flex-wrap items-center gap-2 min-w-0">
-          <StatusBadge status={task.status} />
+          <StatusBadge status={task.status} overdue={isOverdue(task)} />
           <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">{task.taskType}</span>
           {task.recurring && (
             <span className="inline-flex items-center gap-1 rounded-[3px] border border-secondary/30 bg-secondary/15 px-1.5 font-mono text-[10px] text-secondary">
@@ -239,6 +241,30 @@ export default function TaskDetail() {
             #{task.ref} · posted {timeAgo(task.createdAtMs)} · {deadlineLabel(task.deadlineMs, task) ?? fmtDate(task.deadlineMs)}
           </p>
         </div>
+
+        {/*
+          A task past its deadline that has not settled needs to say what happens next.
+          Showing only a status was what made a stalled task look like a broken app rather
+          than a task with a known resolution.
+        */}
+        {overdue && task.status === "ASSIGNED" && (
+          <div className="rounded-[4px] border border-accent/30 bg-accent/10 px-3 py-2.5">
+            <p className="text-xs leading-relaxed text-accent">
+              <span className="font-medium">Overdue.</span> The assigned agent missed the deadline. Enforcing a
+              missed deadline is permissionless, and the runtime does it automatically: your {symbol} is refunded from
+              escrow and the agent's stake is slashed. Nothing is required from you.
+            </p>
+          </div>
+        )}
+        {overdue && task.status === "OPEN" && (
+          <div className="rounded-[4px] border border-accent/30 bg-accent/10 px-3 py-2.5">
+            <p className="text-xs leading-relaxed text-accent">
+              <span className="font-medium">Expired.</span> No agent bid before the deadline, so nothing was ever
+              assigned. Only you can reclaim this one, because only the requester may cancel an open task: use Cancel
+              above and the escrowed {symbol} comes back to you.
+            </p>
+          </div>
+        )}
 
         {eligible && <PlaceBid taskId={task.taskId} budget={task.budgetUsdc} />}
 


### PR DESCRIPTION
Task `#9F65C257` sat at "in progress" and never moved. It was not a display bug — **four defects**, each of which strands a task or fakes a market.

## 1. An empty model response retried forever

`chat()` ended with `?? ""`, so a refusal or truncation became an empty deliverable. The endpoint refused it with `400 "taskId and deliverable required"`, the agent treated that as retryable, and it looped every ~20s — paying for a model call each pass, task pinned in `ASSIGNED`. Production logs showed the loop plainly. Empty completions now throw, marked retryable so the existing ladder gets its chance first.

## 2. The fulfil path had no retry ceiling

Now a durable per-chain budget (`FULFIL_MAX_ATTEMPTS`, default 3), merged on write so concurrent agents don't clobber each other, and persistent so a restart can't reset the count and resume burning credits. The Circle swarm had the same unbounded retry; fixed there too.

## 3. Nothing ever enforced a deadline

`slashOnTimeout` is deliberately permissionless in both registries and refunds the requester while slashing the agent — but nothing called it, and it wasn't even in the runtime's ABI. There were tickers for agents, disputes, hosted agents, subscriptions and recurring plans, and none for tasks.

`server/reaper.js` adds one. Candidates come from the checkpointed index, never a fresh scan (this is the RPC whose throttling once left production serving 4 tasks out of 270), and the chain is consulted once per candidate immediately before acting. Idempotent, treats `Before deadline` / `Not in progress` as no-ops since anyone may have got there first, and runs on the verdict signer so no owner key is involved.

**Grandfathered.** Switching it on found 114 overdue tasks on Arc holding 218 USDC. Since refund and slash are atomic, the first tick would have slashed 4 agents 114 times, taking three to reputation 0 — below BidEngine's floor, permanently unable to bid — for failures caused by the missing reaper itself. Enforcement covers deadlines that pass from startup; `REAPER_ENFORCE_FROM_MS=0` opts into the backlog.

## 4. Only one agent could ever bid

`bidOn` placed a bid then immediately called `awardBid`, closing the auction in the same breath. First agent to poll won by definition; everyone else hit `auctionClosed`. BidEngine's scoring (price 40% / reputation 40% / speed 20%) never had a second bid to compare — and the UI counted down "bidding 19m left" on a task awarded seconds after creation, claiming to mirror a `BID_WINDOW_MS` that existed only in the Circle swarm.

The tick now derives the window from on-chain `createdAt`/`deadline`, clamped to the time remaining, and closes only once it passes. Derived rather than scheduled, because the Circle swarm's `setTimeout` is forgotten on restart — leaving a task OPEN with bids and nothing to award it.

## Also

A task past its deadline reads **Overdue** or **Expired**, not "In progress", and the task page says what resolves each. Two latent bugs fell out: `meta` was `const`-scoped inside the `try` while the `catch` read `meta.title`, so the one branch meant to avoid a pointless retry was the only one that couldn't run; and `StatusBadge` called `Date.now()` during render.

**62 → 85 tests.** They earn it: reverting the `chat()` fix alone fails three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)