### PR TITLE
Price bids in the asset's own precision

### DIFF
--- a/server/agent.js
+++ b/server/agent.js
@@ -350,8 +350,16 @@ class Agent {
 
     this.seen.add(taskId);
     // Price policy: undercut the budget by the agent's markup (lower bid = higher score).
+    //
+    // Rounded to the ASSET's precision, not to 2 decimals. `toFixed(2)` and a hard 0.01
+    // floor are USDC-isms: on an 18-decimal coin a 0.01 BOT budget with a 0.85 markup rounds
+    // straight back to 0.01, so every agent submits the identical bid and BidEngine's price
+    // score (40% of the total) has nothing to discriminate on. Observed on mainnet: four
+    // distinct markups, four identical 0.01 bids.
     const markup = this.cfg.markup ?? 0.85;
-    const bidAmount = Math.max(0.01, +(meta.budgetUsdc * markup).toFixed(2));
+    const dp = this.ctx.asset.decimals >= 18 ? 6 : 2;
+    const floor = 10 ** -dp;
+    const bidAmount = Math.max(floor, +(meta.budgetUsdc * markup).toFixed(dp));
     const etaSeconds = 1800;
     try {
       await this.send(this.bid, "placeBid", [taskId, this.units(bidAmount), etaSeconds], { identityCall: true });

--- a/server/test/stuckTasks.test.js
+++ b/server/test/stuckTasks.test.js
@@ -272,3 +272,33 @@ test("the window is computed from creation, so a restart reaches the same verdic
   const deadline = created + 6 * HOUR;
   assert.equal(auctionState({ createdAtMs: created, deadlineMs: deadline, now: Date.now() }), "award");
 });
+
+/**
+ * Bid pricing has to respect the asset's precision.
+ *
+ * `toFixed(2)` and a hard 0.01 floor are USDC-isms. On BOT Chain a 0.01 budget with a 0.85
+ * markup rounded straight back to 0.01, so four agents with four different markups all
+ * submitted the identical bid and the price component of BidEngine's score (40% of it) could
+ * not discriminate at all. Observed live on mainnet before this was fixed.
+ */
+function bidFor(budget, markup, decimals) {
+  const dp = decimals >= 18 ? 6 : 2;
+  return Math.max(10 ** -dp, +(budget * markup).toFixed(dp));
+}
+
+test("distinct markups produce distinct bids on an 18-decimal coin", () => {
+  const bids = [0.85, 0.8, 0.88, 0.75].map((m) => bidFor(0.01, m, 18));
+  assert.equal(new Set(bids).size, 4, `all four must differ, got ${bids.join(", ")}`);
+  assert.deepEqual(bids, [0.0085, 0.008, 0.0088, 0.0075]);
+});
+
+test("a 6-decimal stablecoin keeps its two-decimal pricing", () => {
+  assert.equal(bidFor(10, 0.85, 6), 8.5);
+  assert.equal(bidFor(1, 0.85, 6), 0.85);
+});
+
+test("the floor scales with the asset instead of being a hardcoded cent", () => {
+  // A hard 0.01 floor on an 18-decimal coin would raise a sub-cent bid ABOVE the budget.
+  assert.equal(bidFor(0.000001, 0.85, 18), 0.000001);
+  assert.ok(bidFor(0.000001, 0.85, 18) <= 0.000001, "a bid must never exceed a tiny budget");
+});


### PR DESCRIPTION
Running four agents against one mainnet task exposed this: **four distinct markups produced four identical 0.01 BOT bids.**

`bidAmount` used `toFixed(2)` and a hard `0.01` floor — both USDC-isms. On an 18-decimal coin a 0.01 budget × 0.85 markup rounds straight back to 0.01, so every agent submits the same number and the price component of BidEngine's score (40% of the total) cannot discriminate at all. The observed scores still differed (55 / 67 / 42) but only on reputation and speed, which is not the auction the design describes.

Rounding now follows the asset: 6 decimals for an 18-decimal native coin, 2 for a 6-decimal stablecoin, floor scaled to match. The old hardcoded floor could also raise a sub-cent bid *above* the budget it was bidding on.

Same class of bug as BidEngine's `PRICE_UNIT`, which was a hardcoded `1_000_000` and silently meant "USDC" until an 18-decimal chain made every price score 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)