### PR TITLE
Never produce work for a task that is already over

### DIFF
--- a/server/agent.js
+++ b/server/agent.js
@@ -64,6 +64,9 @@ const BID_WINDOW_MS = Number(process.env.BID_WINDOW_MS || 20 * 60 * 1000);
  * agent funded for exactly "stake + gas" always failed it.
  */
 const IDENTITY_MINT_RESERVE = ethers.parseEther(process.env.SWARM_IDENTITY_RESERVE || "0.004");
+/** TaskRegistry's Status enum: OPEN, ASSIGNED, IN_PROGRESS, COMPLETED, SETTLED, CANCELLED. */
+const TASK_ASSIGNED = 1;
+const TASK_IN_PROGRESS = 2;
 
 /** `botchain-testnet` → `BOTCHAIN_TESTNET` */
 const envKey = (id) => id.replace(/-/g, "_").toUpperCase();
@@ -91,6 +94,8 @@ class Agent {
     this.wallet = new ethers.Wallet(cfg.key, ctx.provider);
     this.reg = new ethers.Contract(ctx.ADDR.agentRegistry, ctx.ABI.agentRegistry, this.wallet);
     this.bid = new ethers.Contract(ctx.ADDR.bidEngine, ctx.ABI.bidEngine, this.wallet);
+    // Read-only: used to confirm a task is still live and still ours before working on it.
+    this.taskReg = new ethers.Contract(ctx.ADDR.taskRegistry, ctx.ABI.taskRegistry, ctx.provider);
     // Native networks (BOT Chain) have no escrow token, value moves as msg.value.
     this.native = Boolean(ctx.asset.native);
     this.token = this.native ? null : new ethers.Contract(ctx.ADDR.usdc, ctx.ABI.erc20, this.wallet);
@@ -411,6 +416,19 @@ class Agent {
       // retry was the one that could not run.
       let meta = null;
       try {
+        // Is this task still ours to do? `BidAwarded` logs are replayed from the index's
+        // start block, so a task won long ago reappears on every boot. Without this check an
+        // agent that was offline past a deadline comes back, produces a fresh deliverable for
+        // a task the reaper already cancelled and refunded, and then fails on chain with the
+        // escrow's "Already resolved" — having paid for the model call. Observed on mainnet:
+        // an agent burned three attempts and its retry budget on a task that had been dead
+        // for hours.
+        const onChain = await this.taskReg.tasks(taskId);
+        const status = Number(onChain.status);
+        if (status !== TASK_ASSIGNED && status !== TASK_IN_PROGRESS) continue;
+        // And still ours specifically: a reopened task may have been awarded to someone else.
+        if (onChain.assignedAgent.toLowerCase() !== this.address.toLowerCase()) continue;
+
         meta = await this.ctx.readTaskMeta(taskId);
         if (!meta) continue;
         // Optional: pay a sub-cent x402 nanopayment for an oracle quote first.

--- a/server/test/stuckTasks.test.js
+++ b/server/test/stuckTasks.test.js
@@ -364,3 +364,43 @@ test("the tick retries the mint for a registered agent that has no identity", ()
 test("an agent that already holds an identity is never re-minted", () => {
   assert.deepEqual(needsIdentity([{ name: "A", erc8004Id: "7", hasGas: true }]), []);
 });
+
+/* ── 6. Never work a task that is no longer live ──────────────────────────────── */
+
+/**
+ * `fulfilWins` replays `BidAwarded` logs from the index's start block, so a task won long ago
+ * reappears on every boot. It did not check the task's current status first.
+ *
+ * Seen on mainnet: an agent ran out of gas, its task's deadline passed, the reaper cancelled
+ * it and refunded the requester. Hours later the agent was funded, came back, replayed the old
+ * award, paid for a fresh deliverable, and failed on chain with the escrow's "Already
+ * resolved" — burning its whole retry budget on a task that had been dead since the night
+ * before.
+ */
+const TASK = { OPEN: 0, ASSIGNED: 1, IN_PROGRESS: 2, COMPLETED: 3, SETTLED: 4, CANCELLED: 5 };
+
+/** The guard: work it only if it is still assigned, and still assigned to us. */
+function shouldFulfil(onChain, me) {
+  const live = onChain.status === TASK.ASSIGNED || onChain.status === TASK.IN_PROGRESS;
+  return live && onChain.assignedAgent.toLowerCase() === me.toLowerCase();
+}
+
+const ME = "0xCac2a31f431Bb9274bE9430a651b9c6a5d552174";
+
+test("a task the reaper already cancelled is skipped, not re-worked", () => {
+  assert.equal(shouldFulfil({ status: TASK.CANCELLED, assignedAgent: ME }, ME), false);
+});
+
+test("a task that already settled is skipped", () => {
+  assert.equal(shouldFulfil({ status: TASK.SETTLED, assignedAgent: ME }, ME), false);
+});
+
+test("a task reopened and awarded to someone else is skipped", () => {
+  const other = "0xf83e5eafEE455C688B959915E3AFBE28c468571c";
+  assert.equal(shouldFulfil({ status: TASK.ASSIGNED, assignedAgent: other }, ME), false);
+});
+
+test("a live task still assigned to us is worked", () => {
+  assert.equal(shouldFulfil({ status: TASK.ASSIGNED, assignedAgent: ME }, ME), true);
+  assert.equal(shouldFulfil({ status: TASK.IN_PROGRESS, assignedAgent: ME.toLowerCase() }, ME), true);
+});


### PR DESCRIPTION
An agent ran out of gas on mainnet, its task's deadline passed, and the reaper did its job — cancelled the task, refunded the requester, slashed the agent. Hours later the agent was funded, came back, and **immediately produced a fresh deliverable for that same task**, then failed on chain with the escrow's `"Already resolved"`. It burned its whole retry budget, and a model call per attempt, on work that had been dead since the night before.

```
[botchain-mainnet/Nova-Prime] gas restored — resuming
[botchain-mainnet/Nova-Prime] won "Compare BOT Chain and Arc…" — producing deliverable…
fulfil error (attempt 2/3): execution reverted: "Already resolved"
giving up on 0x4da8d4f1 after 3 attempts
```

Confirmed on chain: that task is `CANCELLED` with the escrow already resolved.

## Cause

`fulfilWins` replays `BidAwarded` logs from the index's start block, so every task an agent ever won reappears on each boot, and nothing checked whether those tasks were still live. The in-memory `handled` set hid this during a long uptime and stopped hiding it across a restart.

## Fix

Read the task on chain before doing anything expensive, and skip unless:
- the status is still `ASSIGNED` or `IN_PROGRESS`, and
- it is still assigned to **this** agent — a task can be reopened and awarded to a competitor, and the old winner should not be producing work for it.

One cheap read in front of an LLM call and a transaction.

This also explains a confusing log: `"Already resolved"` reads like a settlement bug, but it is the escrow correctly refusing to pay twice. The mistake was asking.

94 → 98 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)